### PR TITLE
fixing additional (None) in finite_markov

### DIFF
--- a/rst_files/finite_markov.rst
+++ b/rst_files/finite_markov.rst
@@ -424,6 +424,7 @@ Rewriting this statement in terms of  marginal and conditional probabilities giv
 .. _mc_fdd:
 
     .. math::
+
         \psi_{t+1}(y) = \sum_{x \in S} P(x,y) \psi_t(x)
 
 

--- a/rst_files/finite_markov.rst
+++ b/rst_files/finite_markov.rst
@@ -423,9 +423,8 @@ Rewriting this statement in terms of  marginal and conditional probabilities giv
 
 .. _mc_fdd:
 
-.. math::
-
-    \psi_{t+1}(y) = \sum_{x \in S} P(x,y) \psi_t(x)
+    .. math::
+        \psi_{t+1}(y) = \sum_{x \in S} P(x,y) \psi_t(x)
 
 
 There are :math:`n` such equations, one for each :math:`y \in S`


### PR DESCRIPTION
(Issue  #27) in the text of `finite_markov` there is an additional (None) which is not related to text. 
![45193925-00048400-b294-11e8-99d1-df837f1fb26c](https://user-images.githubusercontent.com/20714542/45609802-c9511980-ba9c-11e8-8ecd-9232daaebc18.png)

This is not because of 
`If we think of :math:`\psi_{t+1}` and :math:`\psi_t` as *row vectors* (as is traditional in this literature), these :math:`n` equations are summarized by the matrix expression
 `

this is because of the formula before that. It was something like
```
.. _mc_fdd:

.. math::

\psi_{t+1}(y) = \sum_{x \in S} P(x,y) \psi_t(x)
```

I add some space before `.. math::` like

```
.. _mc_fdd:

    .. math::

    \psi_{t+1}(y) = \sum_{x \in S} P(x,y) \psi_t(x)

```
and that (None) disappeared. 

![screenshot from 2018-09-17 16-59-56](https://user-images.githubusercontent.com/20714542/45609839-fbfb1200-ba9c-11e8-83d4-3de9bc31d595.png)

![screenshot from 2018-09-17 17-08-38](https://user-images.githubusercontent.com/20714542/45609843-fe5d6c00-ba9c-11e8-9c42-8f7fb8373d0f.png)
