### PR TITLE
Fix link in samuelson.rst

### DIFF
--- a/rst_files/finite_markov.rst
+++ b/rst_files/finite_markov.rst
@@ -423,9 +423,8 @@ Rewriting this statement in terms of  marginal and conditional probabilities giv
 
 .. _mc_fdd:
 
-.. math::
-
-    \psi_{t+1}(y) = \sum_{x \in S} P(x,y) \psi_t(x)
+    .. math::
+        \psi_{t+1}(y) = \sum_{x \in S} P(x,y) \psi_t(x)
 
 
 There are :math:`n` such equations, one for each :math:`y \in S`

--- a/rst_files/samuelson.rst
+++ b/rst_files/samuelson.rst
@@ -327,7 +327,7 @@ We use the Samuelson multiplier-accelerator model as a vehicle for teaching how 
 We want to have a method in the class that automatically generates a simulation, either nonstochastic (:math:`\sigma=0`) or stochastic (:math:`\sigma > 0`)
 
 We also show how to map the Samuelson model into a simple instance of
-   the `LinearStateSpace` class described `here <https://lectures.quantecon.org/py/linear\_models.html>`__
+   the `LinearStateSpace` class described `here <https://lectures.quantecon.org/py/linear_models.html>`__
 
 We can use a `LinearStateSpace` instance to do various things that we did above with
    our homemade function and class


### PR DESCRIPTION
in samuelson.rst because of typo the link is dismissed. 
![45400511-c961ab80-b68f-11e8-9c6c-84d73639a171](https://user-images.githubusercontent.com/20714542/45610399-2352de80-ba9f-11e8-8e15-7beeb6b32369.png)
( Issue #27 )