### PR TITLE
fix warning (pandas)

### DIFF
--- a/rst_files/_static/code/pandas/wb_download.py
+++ b/rst_files/_static/code/pandas/wb_download.py
@@ -9,7 +9,7 @@ with open('gd.xls', 'wb') as output:
     output.write(r.content)
 
 # == Parse data into a DataFrame == #
-govt_debt = pd.read_excel('gd.xls', sheetname='Data', skiprows=3, index_col=1)
+govt_debt = pd.read_excel('gd.xls', sheet_name='Data', skiprows=3, index_col=1)
 
 # == Take desired values and plot == #
 govt_debt = govt_debt.transpose()


### PR DESCRIPTION
change the keyword `sheetname` to `sheet_name` because it's deprecated.
Issue  #28
![screenshot from 2018-09-18 16-38-24](https://user-images.githubusercontent.com/20714542/45668775-5bbaf100-bb61-11e8-9a64-b34b88569512.png)


![screenshot from 2018-09-18 16-36-34](https://user-images.githubusercontent.com/20714542/45668776-5bbaf100-bb61-11e8-878e-000efaa21461.png)
