### PR TITLE
[python_advanced_features] remove no-execute tags in rst to allow for generated error output

### DIFF
--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -54,18 +54,15 @@ For example, file objects are iterators
 To see this, let's have another look at the :ref:`US cities data <us_cities_data>` 
 
 .. code-block:: python3
-    :class: no-execute
 
     f = open('us_cities.txt')
     f.__next__()
     
 .. code-block:: none
-    :class: no-execute
     
     'new york: 8244910\n'
     
 .. code-block:: python3
-    :class: no-execute
 
     f.__next__()
     
@@ -79,7 +76,6 @@ The next method can also be accessed via the builtin function ``next()``,
 which directly calls this method
 
 .. code-block:: python3
-    :class: no-execute
 
     next(f)
     
@@ -101,7 +97,6 @@ The objects returned by ``enumerate()`` are also iterators
 as are the reader objects from the ``csv`` module 
 
 .. code-block:: python3
-    :class: no-execute
 
     from csv import reader
 
@@ -110,7 +105,6 @@ as are the reader objects from the ``csv`` module
     next(nikkei_data)
     
 .. code-block:: python3
-    :class: no-execute
 
     next(nikkei_data)
 
@@ -126,7 +120,6 @@ All iterators can be placed to the right of the ``in`` keyword in ``for`` loop s
 In fact this is how the ``for`` loop works:  If we write
 
 .. code-block:: python3
-    :class: no-execute
 
     for x in iterator:
         <code block>
@@ -140,7 +133,6 @@ then the interpreter
 So now you know how this magical looking syntax works
 
 .. code-block:: python3
-    :class: no-execute
 
     f = open('somefile.txt', 'r')
     for line in f:
@@ -181,7 +173,6 @@ The answer is no:
     
     
 .. code-block:: python3
-    :class: no-execute
 
     next(x)
     
@@ -224,7 +215,6 @@ Lists are one such object
     next(y)
     
 .. code-block:: python3
-    :class: no-execute
 
     next(y)
     
@@ -243,7 +233,6 @@ Many other objects are iterable, such as dictionaries and tuples
 Of course, not all objects are iterable 
 
 .. code-block:: python3
-    :class: no-execute
 
     iter(42)
     
@@ -301,7 +290,6 @@ One thing to remember about iterators is that they are depleted by use
 
 
 .. code-block:: python3
-    :class: no-execute
     
     max(y)
     
@@ -417,7 +405,6 @@ To see this in action, suppose we write a script ``math2.py`` like this
 Now we start the Python interpreter and import it 
 
 .. code-block:: python3
-    :class: no-execute
 
     import math2
 
@@ -434,7 +421,6 @@ Both of these modules have an attribute called ``pi``
     math.pi
     
 .. code-block:: python3
-    :class: no-execute
 
     math2.pi
     
@@ -453,7 +439,6 @@ We can look at the dictionary directly, using ``module_name.__dict__``
     math.__dict__
     
 .. code-block:: python3
-    :class: no-execute
 
     import math2
 
@@ -539,17 +524,14 @@ To see this, let's create a file ``mod.py`` that prints its own ``__name__`` att
 Now let's look at two different ways of running it in IPython 
 
 .. code-block:: python3
-    :class: no-execute
 
     import mod  # Standard import
     
 .. code-block:: none
-    :class: no-execute
     
     mod
     
 .. code-block:: ipython
-    :class: no-execute
     
     %run mod.py  # Run interactively
 
@@ -592,7 +574,6 @@ We are now working in the module ``__main__``, and hence the namespace for ``__m
 Next, we import a module called ``amodule`` 
 
 .. code-block:: python3
-    :class: no-execute
 
     import amodule
 
@@ -758,7 +739,6 @@ Consider a script ``test.py`` that looks as follows
 What happens when we run this script?  
 
 .. code-block:: ipython
-    :class: no-execute
 
     %run test.py
     
@@ -767,7 +747,6 @@ What happens when we run this script?
     a = 0 y = 11
 
 .. code-block:: python3
-    :class: no-execute
 
     x
     
@@ -923,7 +902,6 @@ If we run this with an array of length one, the program will terminate and
 print our error message
 
 .. code-block:: python3
-    :class: no-execute
 
     var([1])
     
@@ -971,7 +949,6 @@ Exceptions
 Here's an example of a common error type
 
 .. code-block:: python3
-    :class: no-execute
     
     def f:
 
@@ -988,7 +965,6 @@ Since illegal syntax cannot be executed, a syntax error terminates execution of 
 Here's a different kind of error, unrelated to syntax
 
 .. code-block:: python3
-    :class: no-execute
 
     1 / 0
     
@@ -1004,7 +980,6 @@ Here's a different kind of error, unrelated to syntax
 Here's another
 
 .. code-block:: python3
-    :class: no-execute
 
     x1 = y1
     
@@ -1021,7 +996,6 @@ Here's another
 And another
 
 .. code-block:: python3
-    :class: no-execute
 
     'foo' + 6
     
@@ -1037,7 +1011,6 @@ And another
 And another
 
 .. code-block:: python3
-    :class: no-execute
 
     X = []
     x = X[0]
@@ -1636,7 +1609,6 @@ Let's see how it works after running this code
     next(gen)
     
 .. code-block:: python3
-    :class: no-execute
 
     next(gen)
     
@@ -1712,7 +1684,6 @@ Let's see how it works
     next(gen)
     
 .. code-block:: python3
-    :class: no-execute
     
     next(gen)
     
@@ -1781,7 +1752,6 @@ This uses lots of memory and is very slow
 If we make ``n`` even bigger then this happens
 
 .. code-block:: python3
-    :class: no-execute
 
     n = 1000000000
     draws = [random.uniform(0, 1) < 0.5 for i in range(n)]
@@ -1910,7 +1880,6 @@ Complete the following code, and test it using `this csv file <https://github.co
 
 
 .. code-block:: python3
-    :class: no-execute
 
     def column_iterator(target_file, column_number):
         """A generator function for CSV files.

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -58,17 +58,11 @@ To see this, let's have another look at the :ref:`US cities data <us_cities_data
     f = open('us_cities.txt')
     f.__next__()
     
-.. code-block:: none
-    
-    'new york: 8244910\n'
     
 .. code-block:: python3
 
     f.__next__()
     
-.. code-block:: none
-    
-    'los angeles: 3819702\n'
 
 We see that file objects do indeed have a ``__next__`` method, and that calling this method returns the next line in the file
 
@@ -78,10 +72,6 @@ which directly calls this method
 .. code-block:: python3
 
     next(f)
-    
-.. code-block:: none
-    
-    'chicago: 2707120 \n'
 
 The objects returned by ``enumerate()`` are also iterators 
 
@@ -175,15 +165,6 @@ The answer is no:
 .. code-block:: python3
 
     next(x)
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    TypeError                                 Traceback (most recent call last)
-    <ipython-input-17-5e4e57af3a97> in <module>()
-    ----> 1 next(x)
-
-    TypeError: 'list' object is not an iterator
 
 
 So why can we iterate over a list in a ``for`` loop?
@@ -216,16 +197,7 @@ Lists are one such object
     
 .. code-block:: python3
 
-    next(y)
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    StopIteration                             Traceback (most recent call last)
-    <ipython-input-62-75a92ee8313a> in <module>()
-    ----> 1 y.next()
-
-    StopIteration:         
+    next(y)    
 
 
 Many other objects are iterable, such as dictionaries and tuples
@@ -235,15 +207,6 @@ Of course, not all objects are iterable
 .. code-block:: python3
 
     iter(42)
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    TypeError                                 Traceback (most recent call last)
-    <ipython-input-63-826bbd6e91fc> in <module>()
-    ----> 1 iter(42)
-
-    TypeError: 'int' object is not iterable
 
 
 To conclude our discussion of ``for`` loops
@@ -292,15 +255,6 @@ One thing to remember about iterators is that they are depleted by use
 .. code-block:: python3
     
     max(y)
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    ValueError                                Traceback (most recent call last)
-    <ipython-input-72-1d3b6314f310> in <module>()
-    ----> 1 max(y)
-
-    ValueError: max() arg is an empty sequence
 
 
 .. _name_res:
@@ -424,9 +378,6 @@ Both of these modules have an attribute called ``pi``
 
     math2.pi
     
-.. code-block:: none
-    
-    'foobar'
 
 These two different bindings of ``pi`` exist in different namespaces, each one implemented as a dictionary
 
@@ -443,10 +394,6 @@ We can look at the dictionary directly, using ``module_name.__dict__``
     import math2
 
     math2.__dict__
-    
-.. code-block:: none
-    
-    {..., '__file__': 'math2.py', 'pi': 'foobar',...}  # Edited output
 
 
 As you know, we access elements of the namespace using the dotted attribute notation 
@@ -526,18 +473,12 @@ Now let's look at two different ways of running it in IPython
 .. code-block:: python3
 
     import mod  # Standard import
-    
-.. code-block:: none
-    
-    mod
+
     
 .. code-block:: ipython
     
     %run mod.py  # Run interactively
 
-.. code-block:: none
-
-    __main__
   
 In the second case, the code is executed as part of ``__main__``, so ``__name__`` is equal to ``__main__``
 
@@ -742,22 +683,11 @@ What happens when we run this script?
 
     %run test.py
     
-.. code-block:: none
-    
-    a = 0 y = 11
 
 .. code-block:: python3
 
     x
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    NameError                                 Traceback (most recent call last)
-    <ipython-input-2-401b30e3b8b5> in <module>()
-    ----> 1 x
-
-    NameError: name 'x' is not defined
 
 First,
 
@@ -905,21 +835,6 @@ print our error message
 
     var([1])
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    AssertionError                            Traceback (most recent call last)
-    <ipython-input-20-0032ff8a150f> in <module>()
-    ----> 1 var([1])
-
-    <ipython-input-19-cefafaec3555> in var(y)
-          1 def var(y):
-          2     n = len(y)
-    ----> 3     assert n > 1, 'Sample size must be greater than one.'
-          4     return np.sum((y - y.mean())**2) / float(n-1)
-
-    AssertionError: Sample size must be greater than one.
-
 
 The advantage is that we can
 
@@ -952,12 +867,7 @@ Here's an example of a common error type
     
     def f:
 
-.. code-block:: none
-    
-      File "<ipython-input-5-f5bdb6d29788>", line 1
-        def f:
-            ^
-    SyntaxError: invalid syntax
+
 
 
 Since illegal syntax cannot be executed, a syntax error terminates execution of the program
@@ -968,14 +878,6 @@ Here's a different kind of error, unrelated to syntax
 
     1 / 0
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    ZeroDivisionError                         Traceback (most recent call last)
-    <ipython-input-17-05c9758a9c21> in <module>()
-    ----> 1 1/0
-
-    ZeroDivisionError: integer division or modulo by zero
 
 Here's another
 
@@ -983,14 +885,6 @@ Here's another
 
     x1 = y1
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    NameError                                 Traceback (most recent call last)
-    <ipython-input-23-142e0509fbd6> in <module>()
-    ----> 1 x1 = y1
-
-    NameError: name 'y1' is not defined
 
 
 And another
@@ -999,14 +893,6 @@ And another
 
     'foo' + 6
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    TypeError                                 Traceback (most recent call last)
-    <ipython-input-20-44bbe7e963e7> in <module>()
-    ----> 1 'foo' + 6
-
-    TypeError: cannot concatenate 'str' and 'int' objects
 
 And another
 
@@ -1015,16 +901,6 @@ And another
     X = []
     x = X[0]
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    IndexError                                Traceback (most recent call last)
-    <ipython-input-22-018da6d9fc14> in <module>()
-    ----> 1 x = X[0]
-
-    IndexError: list index out of range
-
-
 
 On each occasion, the interpreter informs us of the error type
 
@@ -1612,14 +1488,6 @@ Let's see how it works after running this code
 
     next(gen)
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    StopIteration                             Traceback (most recent call last)
-    <ipython-input-21-b2c61ce5e131> in <module>()
-    ----> 1 gen.next()
-
-    StopIteration:
 
 
 
@@ -1687,14 +1555,7 @@ Let's see how it works
     
     next(gen)
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    StopIteration                             Traceback (most recent call last)
-    <ipython-input-32-b2c61ce5e131> in <module>()
-    ----> 1 gen.next()
 
-    StopIteration:
 
 
 The call ``gen = g(2)`` binds ``gen`` to a generator
@@ -1756,12 +1617,6 @@ If we make ``n`` even bigger then this happens
     n = 1000000000
     draws = [random.uniform(0, 1) < 0.5 for i in range(n)]
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    MemoryError                               Traceback (most recent call last)
-    <ipython-input-9-20d1ec1dae24> in <module>()
-    ----> 1 draws = [random.uniform(0, 1) < 0.5 for i in range(n)]
 
 We can avoid these problems using iterators
 


### PR DESCRIPTION
- [x] remove ``:no-execute:`` tags in RST to allow for generated error output
- [x] remove relevant ``.. code-block:: none`` (@fkazemian, @natashawatkins)