### PR TITLE
[python_oop] remove no-execute tags in rst to allow for generated error output

### DIFF
--- a/rst_files/python_oop.rst
+++ b/rst_files/python_oop.rst
@@ -798,7 +798,6 @@ Implement :math:`F_n` as a class called ``ECDF``, where
 Your code should work as follows (modulo randomness)
 
 .. code-block:: python3
-    :class: no-execute
 
     from random import uniform
 
@@ -807,7 +806,6 @@ Your code should work as follows (modulo randomness)
     F(0.5)  # Evaluate ecdf at x = 0.5
 
 .. code-block:: python3
-    :class: no-execute
 
     F.observations = [uniform(0, 1) for i in range(1000)]
     F(0.5)

--- a/rst_files/stationary_densities.rst
+++ b/rst_files/stationary_densities.rst
@@ -888,7 +888,6 @@ Use the same parameters
 For the four initial distributions, use the shifted beta distributions
 
 .. code-block:: python3
-    :class: no-execute
 
     ψ_0 = beta(5, 5, scale=0.5, loc=i*2)
 
@@ -948,7 +947,6 @@ In particular, the exercise is to generate `J` boxplot figures, one for each ini
 
 
 .. code-block:: python3
-    :class: no-execute
 
     initial_conditions = np.linspace(8, 0, J)
 


### PR DESCRIPTION
remove no-execute tags in rst to allow for generated error output

Support for '.. code-block:: none' is incomplete in Jupinx #26