### PR TITLE
[python_essentials] remove no-execute tags in rst to allow for generated error output

### DIFF
--- a/rst_files/python_essentials.rst
+++ b/rst_files/python_essentials.rst
@@ -155,15 +155,6 @@ But tuples are not
     x = (1, 2)  
     x[0] = 10  
 
-.. code-block:: none
-
-    ---------------------------------------------------------------------------
-    TypeError                                 Traceback (most recent call last)
-    <python-input-21-6cb4d74ca096> in <module>()
-    ----> 1 x[0]=10
-
-    TypeError: 'tuple' object does not support item assignment
-
 
 We'll say more about the role of mutable and immutable data a bit later
 
@@ -696,30 +687,9 @@ After running this code, the docstring is available
 
     f?
 
-.. code-block:: none
-
-    Type:       function
-    String Form:<function f at 0x2223320>
-    File:       /home/john/temp/temp.py
-    Definition: f(x)
-    Docstring:  This function squares its argument
-
 .. code-block:: ipython
 
     f??
-
-.. code-block:: none
-
-    Type:       function
-    String Form:<function f at 0x2223320>
-    File:       /home/john/temp/temp.py
-    Definition: f(x)
-    Source:
-    def f(x):
-        """
-        This function squares its argument
-        """
-        return x**2
 
 
 With one question mark we bring up the docstring, and with two we get the source code as well

--- a/rst_files/python_essentials.rst
+++ b/rst_files/python_essentials.rst
@@ -151,7 +151,6 @@ Python lists are mutable
 But tuples are not
 
 .. code-block:: python3
-    :class: no-execute
 
     x = (1, 2)  
     x[0] = 10  
@@ -332,7 +331,6 @@ Note that if ``newfile.txt`` is not in the present working directory then this c
 In this case you can shift the file to the pwd or specify the `full path <https://en.wikipedia.org/wiki/Path_%28computing%29>`_ to the file
 
 .. code-block:: python3
-    :class: no-execute
 
     f = open('insert_full_path_to_file/newfile.txt', 'r')
 
@@ -779,7 +777,6 @@ Keyword Arguments
 If you did the exercises in the :ref:`previous lecture <python_by_example>`, you would have come across the statement
 
 .. code-block:: python3
-    :class: no-execute
 
     plt.plot(x, 'b-', label="white noise")
 


### PR DESCRIPTION
- [x] remove :no-execute: tags in RST to allow for generated error output
- [x] remove relevant .. code-block:: none 

Support for '.. code-block:: none' is incomplete in Jupinx #26