### PR TITLE
[sci_libs] remove no-execute tags in rst to allow for generated error output

### DIFF
--- a/rst_files/sci_libs.rst
+++ b/rst_files/sci_libs.rst
@@ -95,7 +95,6 @@ This works fine but for large :math:`n` it is slow
 Here's a C function that will do the same thing
 
 .. code-block:: c
-    :class: no-execute
 
     double geo_prog(double alpha, int n) {
         double current = 1.0;


### PR DESCRIPTION
remove :no-execute: tags in RST to allow for generated error output

Support for '.. code-block:: none' is incomplete in Jupinx #26