### PR TITLE
 [numba] remove no-execute tags in rst to allow for generated error output

### DIFF
--- a/rst_files/numba.rst
+++ b/rst_files/numba.rst
@@ -135,7 +135,6 @@ Compiled languages avoid these overheads with explicit, static types
 For example, consider the following C code, which sums the integers from 1 to 10
 
 .. code-block:: c
-    :class: no-execute
 
     #include <stdio.h>
 


### PR DESCRIPTION
remove :no-execute: tags in RST to allow for generated error output


Support for '.. code-block:: none' is incomplete in Jupinx #26