### PR TITLE
[python_by_example] remove no-execute tags in rst to allow for generated error output

### DIFF
--- a/rst_files/python_by_example.rst
+++ b/rst_files/python_by_example.rst
@@ -372,7 +372,6 @@ This example helps to clarify how the ``for`` loop works:  When we execute a
 loop of the form
 
 .. code-block:: python3
-    :class: no-execute
 
     for variable_name in sequence:
         <code block>
@@ -646,7 +645,6 @@ Here's another example
 With the list comprehension syntax, we can simplify the lines
 
 .. code-block:: python3
-    :class: no-execute
 
     ϵ_values = []
     for i in range(n):
@@ -656,7 +654,6 @@ With the list comprehension syntax, we can simplify the lines
 into
 
 .. code-block:: python3
-    :class: no-execute
 
     ϵ_values = [generator_type() for i in range(n)]
 


### PR DESCRIPTION
- [ ] remove :no-execute: tags in RST to allow for generated error output
- [ ] remove relevant .. code-block:: none

Support for '.. code-block:: none' is incomplete in Jupinx #26