### PR TITLE
[jv] remove no-execute tags in rst to allow for generated error output

### DIFF
--- a/rst_files/jv.rst
+++ b/rst_files/jv.rst
@@ -300,7 +300,6 @@ diagram.  Set
 
 
 .. code-block:: python3
-    :class: no-execute
 
     K = 50
     plot_grid_max, plot_grid_size = 1.2, 100


### PR DESCRIPTION
remove :no-execute: tags in RST to allow for generated error output

Support for '.. code-block:: none' is incomplete in Jupinx #26