### PR TITLE
[oop_intro] remove no-execute tags in rst to allow for generated error output

### DIFF
--- a/rst_files/oop_intro.rst
+++ b/rst_files/oop_intro.rst
@@ -116,7 +116,6 @@ On the other hand, between two numbers it means ordinary addition
 Consider the following expression 
 
 .. code-block:: python3
-    :class: no-execute
 
     '300' + 400
 


### PR DESCRIPTION
- [ ] remove :no-execute: tags in RST to allow for generated error output
- [ ] remove relevant .. code-block:: none

Support for '.. code-block:: none' is incomplete in Jupinx #26