### PR TITLE
fix tags for 'intentional' errors : (debugging.rst)

### DIFF
--- a/rst_files/debugging.rst
+++ b/rst_files/debugging.rst
@@ -130,7 +130,7 @@ We run the first cell block again, generating the same error
     plot_log()  # Call the function, generate plot
 
 .. code-block:: none
-
+    :class: no-execute
     ---------------------------------------------------------------------------
     AttributeError                            Traceback (most recent call last)
     <ipython-input-1-ef5c75a58138> in <module>()

--- a/rst_files/debugging.rst
+++ b/rst_files/debugging.rst
@@ -100,6 +100,7 @@ But let's pretend that we don't understand this for the moment
 We might suspect there's something wrong with ``ax`` but when we try to investigate this object, we get the following exception:
 
 .. code-block:: none
+    :class: no-execute
 
     ---------------------------------------------------------------------------
     NameError                                 Traceback (most recent call last)

--- a/rst_files/debugging.rst
+++ b/rst_files/debugging.rst
@@ -72,6 +72,7 @@ But there's an error here: ``plt.subplots(2, 1)`` should be just ``plt.subplots(
 Here's what happens when we run the code:
 
 .. code-block:: none
+    :class: no-execute
 
     ---------------------------------------------------------------------------
     AttributeError                            Traceback (most recent call last)

--- a/rst_files/oop_intro.rst
+++ b/rst_files/oop_intro.rst
@@ -134,6 +134,7 @@ Some languages might try to guess but Python is *strongly typed*
 * Python will respond instead by raising a ``TypeError``
 
 .. code-block:: none
+    :class: no-execute
 
     ---------------------------------------------------------------------------
     TypeError                                 Traceback (most recent call last)


### PR DESCRIPTION

- [x] ./rst_files/debugging.rst: :class: no-execute 
![screenshot from 2018-10-26 10-29-01](https://user-images.githubusercontent.com/20714542/47536084-1a5cf480-d90a-11e8-9bbe-6140d54dd566.png)
```
Let's consider a simple (and rather contrived) example

.. code-block:: python3
    :class: no-execute

    import numpy as np
    import matplotlib.pyplot as plt

    def plot_log():
        fig, ax = plt.subplots(2, 1)
        x = np.linspace(1, 2, 10)
        ax.plot(x, np.log(x))
        plt.show()

    plot_log()  # Call the function, generate plot


This code is intended to plot the ``log`` function over the interval
```
- [x] ./rst_files/debugging.rst: :class: no-execute 
![screenshot from 2018-10-26 10-38-03](https://user-images.githubusercontent.com/20714542/47536382-5c3a6a80-d90b-11e8-8a7f-79c41e1cc1a4.png)
---------------------------------
- [x] ./rst_files/debugging.rst: :class: no-execute 
- [x] ./rst_files/debugging.rst: :class: no-execute 
- [x] ./rst_files/debugging.rst: :class: no-execute
- [x] ./rst_files/debugging.rst: :class: no-execute 
![screenshot from 2018-10-26 10-42-47](https://user-images.githubusercontent.com/20714542/47536494-0d410500-d90c-11e8-9e58-d18b1a791d9d.png)

---------------------------
- [x] ./rst_files/debugging.rst: :class: no-execute 
- [x] ./rst_files/debugging.rst: :class: no-execute
![screenshot from 2018-10-26 10-45-23](https://user-images.githubusercontent.com/20714542/47536542-627d1680-d90c-11e8-9963-a649d44eacbf.png)
-----------------------------

![screenshot from 2018-10-26 10-35-41](https://user-images.githubusercontent.com/20714542/47536302-02d23b80-d90b-11e8-992a-e8571f4778b3.png)


so I add     `:class: no-execute`:
```
Here's what happens when we run the code:

.. code-block:: none
    :class: no-execute

    ---------------------------------------------------------------------------
    AttributeError                            Traceback (most recent call last)
    <ipython-input-1-ef5c75a58138> in <module>()
          8     plt.show()
          9 
    ---> 10 plot_log()  # Call the function, generate plot

    <ipython-input-1-ef5c75a58138> in plot_log()
          5     fig, ax = plt.subplots(2, 1)
          6     x = np.linspace(1, 2, 10)
    ----> 7     ax.plot(x, np.log(x))
          8     plt.show()
          9 

    AttributeError: 'numpy.ndarray' object has no attribute 'plot'

```
and so on. 

Issue #85