### PR TITLE
fix tags for 'intentional' errors : (python_advanced_features.rst)

### DIFF
--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -87,6 +87,8 @@ The objects returned by ``enumerate()`` are also iterators
 
 as are the reader objects from the ``csv`` module 
 
+.. jupyter-dependency:: _static/code/python_advanced_features/test_table.csv
+
 .. code-block:: python3
 
     from csv import reader

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -736,14 +736,7 @@ What happens when we run this script?
 
     x
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    NameError                                 Traceback (most recent call last)
-    <ipython-input-2-401b30e3b8b5> in <module>()
-    ----> 1 x
 
-    NameError: name 'x' is not defined
 
 First,
 

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -1665,17 +1665,11 @@ This uses lots of memory and is very slow
 If we make ``n`` even bigger then this happens
 
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     n = 1000000000
     draws = [random.uniform(0, 1) < 0.5 for i in range(n)]
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    MemoryError                               Traceback (most recent call last)
-    <ipython-input-9-20d1ec1dae24> in <module>()
-    ----> 1 draws = [random.uniform(0, 1) < 0.5 for i in range(n)]
+
 
 We can avoid these problems using iterators
 

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -226,18 +226,9 @@ Many other objects are iterable, such as dictionaries and tuples
 Of course, not all objects are iterable 
 
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     iter(42)
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    TypeError                                 Traceback (most recent call last)
-    <ipython-input-63-826bbd6e91fc> in <module>()
-    ----> 1 iter(42)
-
-    TypeError: 'int' object is not iterable
 
 
 To conclude our discussion of ``for`` loops

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -519,7 +519,7 @@ Now let's look at two different ways of running it in IPython
     %run mod.py  # Run interactively
 
 .. code-block:: none
-
+    :class: no-execute
     __main__
   
 In the second case, the code is executed as part of ``__main__``, so ``__name__`` is equal to ``__main__``

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -70,6 +70,7 @@ To see this, let's have another look at the :ref:`US cities data <us_cities_data
     f.__next__()
     
 .. code-block:: none
+    :class: no-execute
     
     'los angeles: 3819702\n'
 
@@ -84,6 +85,7 @@ which directly calls this method
     next(f)
     
 .. code-block:: none
+    :class: no-execute
     
     'chicago: 2707120 \n'
 

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -1605,18 +1605,9 @@ Let's see how it works
     next(gen)
     
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
     
     next(gen)
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    StopIteration                             Traceback (most recent call last)
-    <ipython-input-32-b2c61ce5e131> in <module>()
-    ----> 1 gen.next()
-
-    StopIteration:
 
 
 The call ``gen = g(2)`` binds ``gen`` to a generator

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -182,19 +182,10 @@ The answer is no:
     
     
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     next(x)
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    TypeError                                 Traceback (most recent call last)
-    <ipython-input-17-5e4e57af3a97> in <module>()
-    ----> 1 next(x)
-
-    TypeError: 'list' object is not an iterator
-
 
 So why can we iterate over a list in a ``for`` loop?
 

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -728,11 +728,11 @@ What happens when we run this script?
     %run test.py
     
 .. code-block:: none
-    
+    :class: no-execute
     a = 0 y = 11
 
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     x
     

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -915,16 +915,9 @@ Exceptions
 Here's an example of a common error type
 
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
     
     def f:
-
-.. code-block:: none
-    
-      File "<ipython-input-5-f5bdb6d29788>", line 1
-        def f:
-            ^
-    SyntaxError: invalid syntax
 
 
 Since illegal syntax cannot be executed, a syntax error terminates execution of the program
@@ -932,68 +925,33 @@ Since illegal syntax cannot be executed, a syntax error terminates execution of 
 Here's a different kind of error, unrelated to syntax
 
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     1 / 0
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    ZeroDivisionError                         Traceback (most recent call last)
-    <ipython-input-17-05c9758a9c21> in <module>()
-    ----> 1 1/0
 
-    ZeroDivisionError: integer division or modulo by zero
 
 Here's another
 
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     x1 = y1
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    NameError                                 Traceback (most recent call last)
-    <ipython-input-23-142e0509fbd6> in <module>()
-    ----> 1 x1 = y1
-
-    NameError: name 'y1' is not defined
 
 
 And another
 
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     'foo' + 6
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    TypeError                                 Traceback (most recent call last)
-    <ipython-input-20-44bbe7e963e7> in <module>()
-    ----> 1 'foo' + 6
-
-    TypeError: cannot concatenate 'str' and 'int' objects
 
 And another
 
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     X = []
     x = X[0]
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    IndexError                                Traceback (most recent call last)
-    <ipython-input-22-018da6d9fc14> in <module>()
-    ----> 1 x = X[0]
-
-    IndexError: list index out of range
 
 
 

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -404,6 +404,7 @@ Both of these modules have an attribute called ``pi``
     math2.pi
     
 .. code-block:: none
+    :class: no-execute
     
     'foobar'
 
@@ -425,6 +426,7 @@ We can look at the dictionary directly, using ``module_name.__dict__``
     math2.__dict__
     
 .. code-block:: none
+    :class: no-execute
     
     {..., '__file__': 'math2.py', 'pi': 'foobar',...}  # Edited output
 

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -216,18 +216,9 @@ Lists are one such object
     next(y)
     
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
-    next(y)
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    StopIteration                             Traceback (most recent call last)
-    <ipython-input-62-75a92ee8313a> in <module>()
-    ----> 1 y.next()
-
-    StopIteration:         
+    next(y)    
 
 
 Many other objects are iterable, such as dictionaries and tuples

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -78,8 +78,7 @@ which directly calls this method
     next(f)
     
 .. code-block:: none
-    :class: no-execute
-    
+
     'chicago: 2707120 \n'
 
 The objects returned by ``enumerate()`` are also iterators 
@@ -397,7 +396,6 @@ Both of these modules have an attribute called ``pi``
     math2.pi
     
 .. code-block:: none
-    :class: no-execute
     
     'foobar'
 
@@ -419,7 +417,6 @@ We can look at the dictionary directly, using ``module_name.__dict__``
     math2.__dict__
     
 .. code-block:: none
-    :class: no-execute
     
     {..., '__file__': 'math2.py', 'pi': 'foobar',...}  # Edited output
 
@@ -504,7 +501,6 @@ Now let's look at two different ways of running it in IPython
     import mod  # Standard import
     
 .. code-block:: none
-    :class: no-execute
     
     mod
     
@@ -514,7 +510,6 @@ Now let's look at two different ways of running it in IPython
     %run mod.py  # Run interactively
 
 .. code-block:: none
-    :class: no-execute
     __main__
   
 In the second case, the code is executed as part of ``__main__``, so ``__name__`` is equal to ``__main__``
@@ -723,7 +718,6 @@ What happens when we run this script?
     %run test.py
     
 .. code-block:: none
-    :class: no-execute
     a = 0 y = 11
 
 .. code-block:: python3
@@ -1810,7 +1804,6 @@ Exercise 3
 Suppose we have a text file ``numbers.txt`` containing the following lines
 
 .. code-block:: none
-    :class: no-execute
 
     prices
     3

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -881,24 +881,10 @@ If we run this with an array of length one, the program will terminate and
 print our error message
 
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     var([1])
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    AssertionError                            Traceback (most recent call last)
-    <ipython-input-20-0032ff8a150f> in <module>()
-    ----> 1 var([1])
-
-    <ipython-input-19-cefafaec3555> in var(y)
-          1 def var(y):
-          2     n = len(y)
-    ----> 3     assert n > 1, 'Sample size must be greater than one.'
-          4     return np.sum((y - y.mean())**2) / float(n-1)
-
-    AssertionError: Sample size must be greater than one.
 
 
 The advantage is that we can

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -385,10 +385,6 @@ Both of these modules have an attribute called ``pi``
 .. code-block:: python3
 
     math2.pi
-    
-.. code-block:: none
-    
-    'foobar'
 
 These two different bindings of ``pi`` exist in different namespaces, each one implemented as a dictionary
 

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -275,19 +275,10 @@ One thing to remember about iterators is that they are depleted by use
 
 
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
     
     max(y)
     
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    ValueError                                Traceback (most recent call last)
-    <ipython-input-72-1d3b6314f310> in <module>()
-    ----> 1 max(y)
-
-    ValueError: max() arg is an empty sequence
-
 
 .. _name_res:
 

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -396,17 +396,13 @@ We can look at the dictionary directly, using ``module_name.__dict__``
 
     import math
 
-    math.__dict__
+    math.__dict__.items()
     
 .. code-block:: python3
 
     import math2
 
-    math2.__dict__
-    
-.. code-block:: none
-    
-    {..., '__file__': 'math2.py', 'pi': 'foobar',...}  # Edited output
+    math2.__dict__.items()
 
 
 As you know, we access elements of the namespace using the dotted attribute notation 
@@ -431,13 +427,13 @@ Another way to see its contents is to type ``vars(math)``
 
 .. code-block:: python3
 
-    vars(math)
+    vars(math).items()
 
 If you just want to see the names, you can type
 
 .. code-block:: python3
 
-    dir(math)
+    dir(math)[0:10]
 
 Notice the special names ``__doc__`` and ``__name__``
 
@@ -476,7 +472,7 @@ When we run a script using IPython's ``run`` command, the contents of the file a
 
 To see this, let's create a file ``mod.py`` that prints its own ``__name__`` attribute
 
-.. code-block:: python3
+.. code-block:: ipython
 
     %%file mod.py
     print(__name__)
@@ -599,11 +595,11 @@ How does access to these names work?
 
 .. code-block:: python3
 
-    dir()
+    dir()[0:10]
     
 .. code-block:: python3
     
-    dir(__builtins__)
+    dir(__builtins__)[0:10]
 
 We can access elements of the namespace as follows 
 
@@ -702,9 +698,6 @@ What happens when we run this script?
 .. code-block:: ipython
 
     %run test.py
-    
-.. code-block:: none
-    a = 0 y = 11
 
 .. code-block:: python3
     :class: skip-test

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -103,7 +103,6 @@ The objects returned by ``enumerate()`` are also iterators
 as are the reader objects from the ``csv`` module 
 
 .. code-block:: python3
-    :class: no-execute
 
     from csv import reader
 
@@ -112,7 +111,7 @@ as are the reader objects from the ``csv`` module
     next(nikkei_data)
     
 .. code-block:: python3
-    :class: no-execute
+
 
     next(nikkei_data)
 

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -333,7 +333,7 @@ Here's an example of this situation, where the name ``x`` is first bound to one 
     
 .. code-block:: python3
 
-    x = 'bar'  # No names bound to object 164994764
+    x = 'bar'  # No names bound to the first object
 
 What happens here is that the first object, with identity ``164994764`` is garbage collected
 

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -1538,18 +1538,9 @@ Let's see how it works after running this code
     next(gen)
     
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     next(gen)
-    
-.. code-block:: none
-    
-    ---------------------------------------------------------------------------
-    StopIteration                             Traceback (most recent call last)
-    <ipython-input-21-b2c61ce5e131> in <module>()
-    ----> 1 gen.next()
-
-    StopIteration:
 
 
 

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -1817,6 +1817,7 @@ Exercise 3
 Suppose we have a text file ``numbers.txt`` containing the following lines
 
 .. code-block:: none
+    :class: no-execute
 
     prices
     3

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -54,14 +54,12 @@ For example, file objects are iterators
 To see this, let's have another look at the :ref:`US cities data <us_cities_data>` 
 
 .. code-block:: python3
-    :class: no-execute
 
     f = open('us_cities.txt')
     f.__next__()
 
     
 .. code-block:: python3
-    :class: no-execute
 
     f.__next__()
     
@@ -73,13 +71,8 @@ The next method can also be accessed via the builtin function ``next()``,
 which directly calls this method
 
 .. code-block:: python3
-    :class: no-execute
 
     next(f)
-    
-.. code-block:: none
-
-    'chicago: 2707120 \n'
 
 The objects returned by ``enumerate()`` are also iterators 
 
@@ -165,7 +158,7 @@ You already know that we can put a Python list to the right of ``in`` in a ``for
 
 So does that mean that a list is an iterator?
 
-The answer is no: 
+The answer is no
 
 .. code-block:: python3
 
@@ -334,7 +327,7 @@ Here's an example of this situation, where the name ``x`` is first bound to one 
 
     x = 'bar'  # No names bound to the first object
 
-What happens here is that the first object, with identity ``164994764`` is garbage collected
+What happens here is that the first object is garbage collected
 
 In other words, the memory slot that stores that object is deallocated, and returned to the operating system
 
@@ -364,17 +357,16 @@ Python uses multiple namespaces, creating them on the fly as necessary
 
 For example, every time we import a module, Python creates a namespace for that module
 
-To see this in action, suppose we write a script ``math2.py`` like this
+To see this in action, suppose we write a script ``math2.py`` with a single line
 
 .. code-block:: python3
 
-    # Filename: math2.py
+    %%file math2.py
     pi = 'foobar'
 
 Now we start the Python interpreter and import it 
 
 .. code-block:: python3
-    :class: no-execute
 
     import math2
 
@@ -391,7 +383,6 @@ Both of these modules have an attribute called ``pi``
     math.pi
     
 .. code-block:: python3
-    :class: no-execute
 
     math2.pi
     
@@ -410,7 +401,6 @@ We can look at the dictionary directly, using ``module_name.__dict__``
     math.__dict__
     
 .. code-block:: python3
-    :class: no-execute
 
     import math2
 
@@ -490,13 +480,12 @@ To see this, let's create a file ``mod.py`` that prints its own ``__name__`` att
 
 .. code-block:: python3
 
-    # Filename: mod.py
+    %%file mod.py
     print(__name__)
 
 Now let's look at two different ways of running it in IPython 
 
 .. code-block:: python3
-    :class: no-execute
 
     import mod  # Standard import
     
@@ -505,7 +494,6 @@ Now let's look at two different ways of running it in IPython
     mod
     
 .. code-block:: ipython
-    :class: no-execute
     
     %run mod.py  # Run interactively
 
@@ -699,7 +687,8 @@ Here's an example that helps to illustrate
 Consider a script ``test.py`` that looks as follows
 
 .. code-block:: python3
- 
+
+    %%file test.py
     def g(x):
         a = 1
         x = x + a
@@ -713,7 +702,6 @@ Consider a script ``test.py`` that looks as follows
 What happens when we run this script?  
 
 .. code-block:: ipython
-    :class: no-execute
 
     %run test.py
     

--- a/rst_files/python_advanced_features.rst
+++ b/rst_files/python_advanced_features.rst
@@ -58,21 +58,14 @@ To see this, let's have another look at the :ref:`US cities data <us_cities_data
 
     f = open('us_cities.txt')
     f.__next__()
-    
-.. code-block:: none
-    :class: no-execute
-    
-    'new york: 8244910\n'
+
     
 .. code-block:: python3
     :class: no-execute
 
     f.__next__()
     
-.. code-block:: none
-    :class: no-execute
-    
-    'los angeles: 3819702\n'
+
 
 We see that file objects do indeed have a ``__next__`` method, and that calling this method returns the next line in the file
 


### PR DESCRIPTION
**python_advanced_features.rst**
for this lecture, If I change something I explained it on separate comments, and If I leave some tags unchanged, so I explained them here: 

- [x] ./rst_files/python_advanced_features.rst: :class: no-execute     **commit 1**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute
![screenshot from 2018-10-26 12-14-09](https://user-images.githubusercontent.com/20714542/47538782-d02f3f80-d918-11e8-9dca-6f4e289e4a6f.png)

the code is:
```
To see this, let's have another look at the :ref:`US cities data <us_cities_data>` 

.. code-block:: python3
    :class: no-execute

    f = open('us_cities.txt')
    f.__next__()
    
.. code-block:: none
    :class: no-execute
    
    'new york: 8244910\n'
    
.. code-block:: python3
    :class: no-execute

    f.__next__()
    
.. code-block:: none
    
    'los angeles: 3819702\n'

We see that file objects do indeed have a ``__next__`` method, and that calling this method returns the next line in the file

The next method can also be accessed via the builtin function ``next()``,
which directly calls this method

.. code-block:: python3
    :class: no-execute

    next(f)
```
If we run blocks, we get an error which we can't find the file to open it. so I think we should leave it in a no-execute way and show the results as a none block with no execute tags! Am I right?

---------------------------------------------------
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute      **commit 2**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute        **commit 3**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute
![screenshot from 2018-10-26 12-38-20](https://user-images.githubusercontent.com/20714542/47539417-1a65f000-d91c-11e8-838d-9564899b5724.png)
```
In fact this is how the ``for`` loop works:  If we write

.. code-block:: python3
    :class: no-execute

    for x in iterator:
        <code block>

```

- [x] ./rst_files/python_advanced_features.rst: :class: no-execute
![screenshot from 2018-10-26 12-39-50](https://user-images.githubusercontent.com/20714542/47539476-59944100-d91c-11e8-8415-654184a3b9be.png)
```
So now you know how this magical looking syntax works

.. code-block:: python3
    :class: no-execute

    f = open('somefile.txt', 'r')
    for line in f:
        # do something

```

- [x] ./rst_files/python_advanced_features.rst: :class: no-execute     **commit 4**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute     **commit 5**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute     **commit 6**
-----------------
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute
![screenshot from 2018-10-26 13-31-44](https://user-images.githubusercontent.com/20714542/47541066-99aaf200-d923-11e8-8c89-06dddfcc3e82.png)
```
.. code-block:: python3
    :class: no-execute

    import math2

Next let's import the ``math`` module from the standard library 

.. code-block:: python3

    import math

Both of these modules have an attribute called ``pi``

.. code-block:: python3

    math.pi
    
.. code-block:: python3
    :class: no-execute

    math2.pi
```

```
.. code-block:: python3
    :class: no-execute

    import math2

    math2.__dict__
```
we can't run  import math2 because we get `ModuleNotFoundError`

----------------
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute
![screenshot from 2018-10-26 13-38-06](https://user-images.githubusercontent.com/20714542/47541311-8c423780-d924-11e8-9610-9cec10837648.png)
```
.. code-block:: python3
    :class: no-execute

    import mod  # Standard import
    
.. code-block:: none
    :class: no-execute
    
    mod
    
.. code-block:: ipython
    :class: no-execute
    
    %run mod.py  # Run interactively


```
we can't run import mode because we get ModuleNotFoundError: No module named 'mod'
I also add  :class: no-execute to none block  in commit 7:
```
.. code-block:: none
    :class: no-execute
    __main__
  

```
----------------------
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute

![screenshot from 2018-10-26 13-50-28](https://user-images.githubusercontent.com/20714542/47541752-353d6200-d926-11e8-9f93-7bdecdecb224.png)
the code is 
```
.. code-block:: python3
    :class: no-execute

    import amodule
```

If we run it we get `ModuleNotFoundError: No module named 'amodule'`

- [x] ./rst_files/python_advanced_features.rst: :class: no-execute **commit 8**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute **commit 8**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute  **commit10**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute   **commit11**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute   **commit11**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute   **commit11**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute   **commit11**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute   **commit11**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute   **commit12**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute    **commit13**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute    **commit14**
- [x] ./rst_files/python_advanced_features.rst: :class: no-execute
![screenshot from 2018-10-26 14-49-42](https://user-images.githubusercontent.com/20714542/47543564-95d09d00-d92e-11e8-901a-bce938485239.png)

the code is:
```
.. code-block:: python3
    :class: no-execute

    def column_iterator(target_file, column_number):
        """A generator function for CSV files.
        When called with a file name target_file (string) and column number
        column_number (integer), the generator function returns a generator
        that steps through the elements of column column_number in file
        target_file.
        """
        # put your code here

    dates = column_iterator('test_table.csv', 1)

    for date in dates:
        print(date)

```
It should never be executed , so It's fine.

--------------------------
---------------------------
- [x] ./rst_files/python_advanced_features.rst:.. code-block:: none             **commit15**
- [x] ./rst_files/python_advanced_features.rst:.. code-block:: none             **commit16**