### PR TITLE
fix tags for 'intentional' errors : (python_by_example.rst)

### DIFF
--- a/rst_files/python_by_example.rst
+++ b/rst_files/python_by_example.rst
@@ -647,7 +647,6 @@ Here's another example
 With the list comprehension syntax, we can simplify the lines
 
 .. code-block:: python3
-    :class: no-execute
 
     ϵ_values = []
     for i in range(n):
@@ -657,7 +656,6 @@ With the list comprehension syntax, we can simplify the lines
 into
 
 .. code-block:: python3
-    :class: no-execute
 
     ϵ_values = [generator_type() for i in range(n)]
 

--- a/rst_files/python_by_example.rst
+++ b/rst_files/python_by_example.rst
@@ -647,6 +647,7 @@ Here's another example
 With the list comprehension syntax, we can simplify the lines
 
 .. code-block:: python3
+    :no-execute:
 
     ϵ_values = []
     for i in range(n):
@@ -656,6 +657,7 @@ With the list comprehension syntax, we can simplify the lines
 into
 
 .. code-block:: python3
+    :no-execute:
 
     ϵ_values = [generator_type() for i in range(n)]
 

--- a/rst_files/python_by_example.rst
+++ b/rst_files/python_by_example.rst
@@ -647,7 +647,7 @@ Here's another example
 With the list comprehension syntax, we can simplify the lines
 
 .. code-block:: python3
-    :no-execute:
+    :class: no-execute
 
     ϵ_values = []
     for i in range(n):
@@ -657,7 +657,7 @@ With the list comprehension syntax, we can simplify the lines
 into
 
 .. code-block:: python3
-    :no-execute:
+    :class: no-execute
 
     ϵ_values = [generator_type() for i in range(n)]
 

--- a/rst_files/python_by_example.rst
+++ b/rst_files/python_by_example.rst
@@ -162,6 +162,7 @@ In fact you can find and explore the directory for NumPy on your computer easily
 On this machine it's located in
 
 .. code-block:: none
+    :class: no-execute
 
     anaconda3/lib/python3.6/site-packages/numpy
 

--- a/rst_files/python_by_example.rst
+++ b/rst_files/python_by_example.rst
@@ -161,7 +161,7 @@ In fact you can find and explore the directory for NumPy on your computer easily
 
 On this machine it's located in
 
-.. code-block:: none
+.. code-block:: ipython
     :class: no-execute
 
     anaconda3/lib/python3.6/site-packages/numpy


### PR DESCRIPTION
**python_by_example**

- [x] ./rst_files/python_by_example.rst:..

 code-block:: none

![screenshot from 2018-10-26 15-37-16](https://user-images.githubusercontent.com/20714542/47544906-12ff1080-d935-11e8-91f0-7309c4a68347.png)

I add    ` :class: no-execute` tag to the block:

```
.. code-block:: none
    :class: no-execute

    anaconda3/lib/python3.6/site-packages/numpy
```

- [x] ./rst_files/python_by_example.rst: :class: no-execute 
![screenshot from 2018-10-26 09-59-26](https://user-images.githubusercontent.com/20714542/47535134-f1d2fb80-d905-11e8-8ee2-696caf7dcc48.png)
```
This example helps to clarify how the ``for`` loop works:  When we execute a
loop of the form

.. code-block:: python3
    :class: no-execute

    for variable_name in sequence:
        <code block>

The Python interpreter performs the following:
```
- [x] ./rst_files/python_by_example.rst: :class: no-execute 
- [x] ./rst_files/python_by_example.rst: :class: no-execute 

With the list comprehension syntax, we can simplify the lines
![screenshot from 2018-10-26 10-01-55](https://user-images.githubusercontent.com/20714542/47535253-52623880-d906-11e8-8731-17b0a3f8f3cb.png)

```
.. code-block:: python3
    :class: no-execute

    ϵ_values = []
    for i in range(n):
        e = generator_type()
        ϵ_values.append(e)

into

.. code-block:: python3
    :class: no-execute

    ϵ_values = [generator_type() for i in range(n)]


```