### PR TITLE
[CONF] update conf to ignore skip-test tags for compilation of website

### DIFF
--- a/rst_files/conf.py
+++ b/rst_files/conf.py
@@ -419,4 +419,8 @@ jupyter_allow_html_only = True
 #Adjust links to target html (rather than ipynb)
 jupyter_target_html = True
 
+#Allow ipython as a language synonym for blocks to be ipython highlighted
 jupyter_lang_synonyms = ["ipython"]
+
+#Execute skip-test code blocks for rendering of website (this will need to be ignored in coverage testing)
+jupyter_ignore_skip_test = True


### PR DESCRIPTION
Adding this will ensure `skip-test` elements will be executed for the `html` rendering of the site. 