### PR TITLE
fix tags for 'intentional' errors : (oop_intro.rst)

### DIFF
--- a/rst_files/oop_intro.rst
+++ b/rst_files/oop_intro.rst
@@ -133,16 +133,6 @@ Some languages might try to guess but Python is *strongly typed*
 
 * Python will respond instead by raising a ``TypeError``
 
-.. code-block:: ipython
-    :class: no-execute
-
-    ---------------------------------------------------------------------------
-    TypeError                                 Traceback (most recent call last)
-    <ipython-input-1-9b7dffd27f2d> in <module>()
-    ----> 1 '300' + 400
-
-    TypeError: Can't convert 'int' object to str implicitly
-
 
 To avoid the error, you need to clarify by changing the relevant type  
 

--- a/rst_files/oop_intro.rst
+++ b/rst_files/oop_intro.rst
@@ -116,7 +116,7 @@ On the other hand, between two numbers it means ordinary addition
 Consider the following expression 
 
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     '300' + 400
 
@@ -133,7 +133,8 @@ Some languages might try to guess but Python is *strongly typed*
 
 * Python will respond instead by raising a ``TypeError``
 
-.. code-block:: none
+.. code-block:: ipython
+    :class: no-execute
 
     ---------------------------------------------------------------------------
     TypeError                                 Traceback (most recent call last)


### PR DESCRIPTION
adjust skip-test and no-execution tags

@natashawatkins I modified this PR to use `skip-test` for the execution component. 

For ``.. code-block:: none`` I have changed this to use ``no-execute`` so it can be highlighted in the text as markdown. However the output will now show twice (once after the cell is executed and once as a discussion piece in the lecture). I will render this lecture to see what it looks like. What do you think?