### PR TITLE
edit tags in python_essentials.rst

### DIFF
--- a/rst_files/python_essentials.rst
+++ b/rst_files/python_essentials.rst
@@ -151,19 +151,10 @@ Python lists are mutable
 But tuples are not
 
 .. code-block:: python3
-    :class: no-execute
+    :class: skip-test
 
     x = (1, 2)  
     x[0] = 10  
-
-.. code-block:: none
-
-    ---------------------------------------------------------------------------
-    TypeError                                 Traceback (most recent call last)
-    <python-input-21-6cb4d74ca096> in <module>()
-    ----> 1 x[0]=10
-
-    TypeError: 'tuple' object does not support item assignment
 
 
 We'll say more about the role of mutable and immutable data a bit later
@@ -698,7 +689,8 @@ After running this code, the docstring is available
 
     f?
 
-.. code-block:: none
+.. code-block:: ipython
+    :class: no-execute
 
     Type:       function
     String Form:<function f at 0x2223320>
@@ -710,7 +702,8 @@ After running this code, the docstring is available
 
     f??
 
-.. code-block:: none
+.. code-block:: ipython
+    :class: no-execute
 
     Type:       function
     String Form:<function f at 0x2223320>


### PR DESCRIPTION
@mmcky we're currently manually copying the output from `f?` and `f??` - is there no way that the build system can compile the docstring? Probably not because as you say, it's in a popup.