### PR TITLE
Add matplotlib inline and update to ipython blocks

### DIFF
--- a/rst_files/about_py.rst
+++ b/rst_files/about_py.rst
@@ -412,10 +412,11 @@ One well-known example is `NetworkX <http://networkx.github.io/>`_
 
 Here's some example code that generates and plots a random graph, with node color determined by shortest path length from a central node
 
-.. code-block:: python3
+.. code-block:: ipython
 
   import networkx as nx
   import matplotlib.pyplot as plt
+  %matplotlib inline
   np.random.seed(1234)
 
   # Generate random graph

--- a/rst_files/amss.rst
+++ b/rst_files/amss.rst
@@ -787,9 +787,10 @@ triangle denote war
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     # Initialize μgrid for value function iteration
     μ_grid = np.linspace(-0.7, 0.01, 200)

--- a/rst_files/amss2.rst
+++ b/rst_files/amss2.rst
@@ -437,9 +437,10 @@ debt equal to :math:`b_0 = -1.038698407551764`
 
 These graphs report outcomes for both the Lucas-Stokey economy with complete markets and the AMSS economy with one-period risk-free debt only
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     μ_grid = np.linspace(-0.09, 0.1, 100)
 

--- a/rst_files/amss3.rst
+++ b/rst_files/amss3.rst
@@ -150,9 +150,10 @@ government debt equal to :math:`-.5`
 
 Here is a graph of a long simulation of 102000 periods
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     μ_grid = np.linspace(-0.09, 0.1, 100)
 

--- a/rst_files/arellano.rst
+++ b/rst_files/arellano.rst
@@ -456,9 +456,10 @@ Solutions
 
 Compute the value function, policy and equilibrium prices
 
-.. code-block:: python3
+.. code-block:: ipython
     
-    import matplotlib.pyplot as plt 
+    import matplotlib.pyplot as plt
+    %matplotlib inline
 
     ae = Arellano_Economy(β=.953,        # time discount rate
                           γ=2.,          # risk aversion

--- a/rst_files/arma.rst
+++ b/rst_files/arma.rst
@@ -234,10 +234,11 @@ The next figure plots an example of this function for :math:`\phi = 0.8` and :ma
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     import matplotlib.pyplot as plt
+    %matplotlib inline
     
     num_rows, num_cols = 2, 1
     fig, axes = plt.subplots(num_rows, num_cols, figsize=(10, 8))

--- a/rst_files/calvo.rst
+++ b/rst_files/calvo.rst
@@ -559,11 +559,12 @@ The bliss level of inflation is denoted by :math:`\theta^*`
 
 First we will create a class `ChangLQ` that solves the models and stores their values
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     from quantecon import LQ
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
 
     class ChangLQ:

--- a/rst_files/career.rst
+++ b/rst_files/career.rst
@@ -26,9 +26,10 @@ This exposition draws on the presentation in :cite:`Ljungqvist2012`, section 6.5
 
 We begin with some imports
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
     import numpy as np
     import quantecon as qe
     from numba import njit, prange

--- a/rst_files/chang_credible.rst
+++ b/rst_files/chang_credible.rst
@@ -791,10 +791,11 @@ The following plot shows both the set of :math:`w,\theta` pairs associated with 
 and the smaller set of :math:`w,\theta` pairs associated with  sustainable plans (in blue)
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import polytope
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     def plot_equilibria(ChangModel):
         """

--- a/rst_files/chang_ramsey.rst
+++ b/rst_files/chang_ramsey.rst
@@ -855,10 +855,11 @@ The package can be installed in a terminal/command prompt with pip
     ch1 = ChangModel(β=0.3, mbar=30, h_min=0.9, h_max=2, n_h=8, n_m=35, N_g=10)
     ch1.solve_sustainable()
 
-.. code-block:: python3
+.. code-block:: ipython
 
   import polytope
   import matplotlib.pyplot as plt
+  %matplotlib inline
 
 
   def plot_competitive(ChangModel):

--- a/rst_files/coleman_policy_iter.rst
+++ b/rst_files/coleman_policy_iter.rst
@@ -433,9 +433,10 @@ solution
 
 We assume the following imports
    
-.. code-block:: python3 
+.. code-block:: ipython 
 
-    import matplotlib.pyplot as plt 
+    import matplotlib.pyplot as plt
+    %matplotlib inline
     import quantecon as qe
 
 

--- a/rst_files/debugging.rst
+++ b/rst_files/debugging.rst
@@ -48,11 +48,12 @@ The ``debug`` Magic
 
 Let's consider a simple (and rather contrived) example
 
-.. code-block:: python3
+.. code-block:: ipython
     :class: skip-test
 
     import numpy as np
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     def plot_log():
         fig, ax = plt.subplots(2, 1)

--- a/rst_files/discrete_dp.rst
+++ b/rst_files/discrete_dp.rst
@@ -722,10 +722,11 @@ Written jointly with `Diasuke Oyama <https://github.com/oyamad>`__
 
 Let's start with some imports
 
-.. code-block:: python3 
+.. code-block:: ipython 
 
     import scipy.sparse as sparse
     import matplotlib.pyplot as plt
+    %matplotlib inline
     from quantecon import compute_fixed_point
     from quantecon.markov import DiscreteDP
 

--- a/rst_files/egm_policy_iter.rst
+++ b/rst_files/egm_policy_iter.rst
@@ -162,9 +162,10 @@ Let's test out the code above on some example parameterizations, after the follo
 
 
    
-.. code-block:: python3 
+.. code-block:: ipython 
 
-    import matplotlib.pyplot as plt 
+    import matplotlib.pyplot as plt
+    %matplotlib inline 
     import quantecon as qe
 
 

--- a/rst_files/estspec.rst
+++ b/rst_files/estspec.rst
@@ -216,9 +216,10 @@ where :math:`\{ \epsilon_t \}` is white noise with unit variance, and compares t
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
     from quantecon import ARMA, periodogram
 
     n = 40                          # Data size

--- a/rst_files/finite_markov.rst
+++ b/rst_files/finite_markov.rst
@@ -899,6 +899,7 @@ The convergence in the theorem is illustrated in the next figure
 
   from mpl_toolkits.mplot3d import Axes3D
   import matplotlib.pyplot as plt
+  %matplotlib inline
 
   P = ((0.971, 0.029, 0.000),
        (0.145, 0.778, 0.077),

--- a/rst_files/finite_markov.rst
+++ b/rst_files/finite_markov.rst
@@ -895,7 +895,7 @@ The convergence in the theorem is illustrated in the next figure
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
   from mpl_toolkits.mplot3d import Axes3D
   import matplotlib.pyplot as plt
@@ -1387,7 +1387,7 @@ Solutions
 
 
 
-.. code-block:: ipython
+.. code-block:: python3
 
     import numpy as np
     import matplotlib.pyplot as plt

--- a/rst_files/finite_markov.rst
+++ b/rst_files/finite_markov.rst
@@ -1387,7 +1387,7 @@ Solutions
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     import matplotlib.pyplot as plt

--- a/rst_files/getting_started.rst
+++ b/rst_files/getting_started.rst
@@ -298,10 +298,11 @@ Here's an arbitrary program we can use: http://matplotlib.org/1.4.1/examples/pie
 
 On that page you'll see the following code
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     N = 20
     θ = np.linspace(0.0, 2 * np.pi, N, endpoint=False)

--- a/rst_files/hist_dep_policies.rst
+++ b/rst_files/hist_dep_policies.rst
@@ -674,9 +674,10 @@ The next figure uses the program to compute and show the Ramsey plan for :math:`
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     fig, axes = plt.subplots(3, 1, figsize=(10, 12))
 

--- a/rst_files/ifp.rst
+++ b/rst_files/ifp.rst
@@ -502,9 +502,10 @@ The following figure is a 45 degree diagram showing the law of motion for assets
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
     import quantecon as qe
     
 

--- a/rst_files/kalman.rst
+++ b/rst_files/kalman.rst
@@ -90,7 +90,7 @@ This density :math:`p(x)` is shown below as a contour map, with the center of th
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
   :class: collapse
 
   from scipy import linalg
@@ -98,6 +98,7 @@ This density :math:`p(x)` is shown below as a contour map, with the center of th
   import matplotlib.cm as cm
   from matplotlib.mlab import bivariate_normal
   import matplotlib.pyplot as plt
+  %matplotlib inline
 
   # == Set up the Gaussian prior density p == #
   Σ = [[0.4, 0.3], [0.3, 0.45]]

--- a/rst_files/lake_model.rst
+++ b/rst_files/lake_model.rst
@@ -276,9 +276,10 @@ Let's run a simulation under the default parameters (see above) starting from :m
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
   import matplotlib.pyplot as plt
+  %matplotlib inline
 
   lm = LakeModel()
   N_0 = 150      # Population

--- a/rst_files/linear_algebra.rst
+++ b/rst_files/linear_algebra.rst
@@ -84,9 +84,10 @@ The following figure represents three vectors in this manner
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
   import matplotlib.pyplot as plt
+  %matplotlib inline
 
   fig, ax = plt.subplots(figsize=(10, 8))
   # Set the axes through the origin

--- a/rst_files/lln_clt.rst
+++ b/rst_files/lln_clt.rst
@@ -214,12 +214,13 @@ In each of the three cases, convergence of :math:`\bar X_n` to :math:`\mu` occur
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import random
     import numpy as np
     from scipy.stats import t, beta, lognorm, expon, gamma, poisson
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     n = 100
 

--- a/rst_files/lu_tricks.rst
+++ b/rst_files/lu_tricks.rst
@@ -981,9 +981,10 @@ Here's some code that generates a plot when :math:`\gamma = 0.8`
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
     
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     # == Set seed and generate a_t sequence == #
     np.random.seed(123)

--- a/rst_files/lucas_model.rst
+++ b/rst_files/lucas_model.rst
@@ -33,13 +33,14 @@ Another difference to our :doc:`first asset pricing lecture <markov_asset>` is t
 
 Let's start with some imports
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     from interpolation import interp
     from numba import njit, prange
     from scipy.stats import lognorm
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
 
 The Lucas Model

--- a/rst_files/markov_asset.rst
+++ b/rst_files/markov_asset.rst
@@ -322,10 +322,11 @@ The next figure shows a simulation, where
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     import matplotlib.pyplot as plt
+    %matplotlib inline
     import quantecon as qe
 
     mc = qe.tauchen(0.96, 0.25, n=25)  

--- a/rst_files/matplotlib.rst
+++ b/rst_files/matplotlib.rst
@@ -58,9 +58,10 @@ The MATLAB-style API
 
 Here's the kind of easy example you might find in introductory treatments
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
     import numpy as np
 
     x = np.linspace(0, 10, 200)

--- a/rst_files/matsuyama.rst
+++ b/rst_files/matsuyama.rst
@@ -444,9 +444,10 @@ Solutions
 
 These solutions are written by `Chase Coleman <github.com/cc7768>`__
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     def plot_attraction_basis(s1=0.5, θ=2.5, δ=0.7, ρ=0.2, npts=250, ax=None):
         if ax is None:

--- a/rst_files/mccall_model.rst
+++ b/rst_files/mccall_model.rst
@@ -304,11 +304,12 @@ Let's start with some imports
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     from numba import jit
     import matplotlib.pyplot as plt
+    %matplotlib inline
     import quantecon as qe
     from quantecon.distributions import BetaBinomial
 

--- a/rst_files/mccall_model_with_separation.rst
+++ b/rst_files/mccall_model_with_separation.rst
@@ -32,12 +32,13 @@ Once separation enters the picture, the agent comes to view
 
 We'll need the following imports
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     from quantecon.distributions import BetaBinomial
     from numba import njit
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
 The Model 
 ============

--- a/rst_files/mle.rst
+++ b/rst_files/mle.rst
@@ -96,11 +96,12 @@ We can plot the Poisson distribution over :math:`y` for different values of :mat
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     from numpy import exp
     from scipy.special import factorial
     import matplotlib.pyplot as plt
+    %matplotlib inline
     
     poisson_pmf = lambda y, μ: μ**y / factorial(y) * exp(-μ)
     y_values = range(0, 25)

--- a/rst_files/numba.rst
+++ b/rst_files/numba.rst
@@ -321,9 +321,10 @@ For :math:`f` and :math:`a` let's choose
 
 Here's a plot of :math:`f`
 
-.. code-block:: python3
+.. code-block:: ipython
 
   import matplotlib.pyplot as plt
+  %matplotlib inline
   from mpl_toolkits.mplot3d.axes3d import Axes3D
   from matplotlib import cm
 

--- a/rst_files/numpy.rst
+++ b/rst_files/numpy.rst
@@ -906,9 +906,10 @@ Solutions
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
 Exercise 1
 ----------

--- a/rst_files/odu.rst
+++ b/rst_files/odu.rst
@@ -31,13 +31,14 @@ In the version considered below, the wage distribution is unknown and must be le
 
 Let's start with some imports
 
-.. code-block:: python3
+.. code-block:: ipython
 
     from numba import njit, prange, vectorize
     from interpolation import mlinterp, interp
     from math import gamma
     import numpy as np
     import matplotlib.pyplot as plt
+    %matplotlib inline
     from matplotlib import cm
 
 

--- a/rst_files/ols.rst
+++ b/rst_files/ols.rst
@@ -84,9 +84,10 @@ Let's use a scatterplot to see whether any obvious relationship exists
 between GDP per capita and the protection against
 expropriation index 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
     plt.style.use('seaborn')
     
     df1.plot(x='avexpr', y='logpgp95', kind='scatter')

--- a/rst_files/opt_tax_recur.rst
+++ b/rst_files/opt_tax_recur.rst
@@ -1130,9 +1130,10 @@ We can now plot the Ramsey tax  under both realizations of time :math:`t = 3` go
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     time_π = np.array([[0, 1, 0,   0,   0,  0],
                        [0, 0, 1,   0,   0,  0],

--- a/rst_files/optgrowth.rst
+++ b/rst_files/optgrowth.rst
@@ -44,10 +44,11 @@ because it comes in handy later when we want to just-in-time compile our code
 
 This library can be installed with the following command in Jupyter: ``!pip install interpolation``
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     import matplotlib.pyplot as plt
+    %matplotlib inline
     from interpolation import interp
     from numba import njit, prange
     from quantecon.optimize.scalar_maximization import brent_max

--- a/rst_files/pandas.rst
+++ b/rst_files/pandas.rst
@@ -245,9 +245,10 @@ One of the nice things about pandas ``DataFrame`` and ``Series`` objects is that
 
 For example, we can easily generate a bar plot of GDP per capita
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     df['GDP percap'].plot(kind='bar')    
     plt.show()

--- a/rst_files/pandas_panel.rst
+++ b/rst_files/pandas_panel.rst
@@ -396,12 +396,12 @@ rows)
 Using this series, we can plot the average real minimum wage over the
 past decade for each country in our data set
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
     import matplotlib
     matplotlib.style.use('seaborn')
-    %matplotlib inline
     
     merged.mean().sort_values(ascending=False).plot(kind='bar', title="Average real minimum wage 2006 - 2016")
     

--- a/rst_files/perm_income.rst
+++ b/rst_files/perm_income.rst
@@ -39,9 +39,10 @@ Background readings on the linear-quadratic-Gaussian permanent income model are 
 
 Let's start with some imports
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
     import numpy as np
     import random
     from numba import njit

--- a/rst_files/perm_income_cons.rst
+++ b/rst_files/perm_income_cons.rst
@@ -355,12 +355,13 @@ First we create the objects for the optimal linear regulator
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import quantecon as qe
     import numpy as np
     import scipy.linalg as la
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     # Set parameters
     α, β, ρ1, ρ2, σ = 10.0, 0.95, 0.9, 0.0, 1.0

--- a/rst_files/python_by_example.rst
+++ b/rst_files/python_by_example.rst
@@ -74,10 +74,11 @@ Version 1
 
 Here's a few lines of code that perform the task we set
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     x = np.random.randn(100)
     plt.plot(x)

--- a/rst_files/python_oop.rst
+++ b/rst_files/python_oop.rst
@@ -439,9 +439,10 @@ Here's a little program that uses the class to compute  time series from two dif
 
 The common steady state is also plotted for comparison
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
     
     s1 = Solow()  
     s2 = Solow(k=8.0)

--- a/rst_files/rational_expectations.rst
+++ b/rst_files/rational_expectations.rst
@@ -671,10 +671,11 @@ Solutions
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
 We'll use the LQ class from quantecon
 

--- a/rst_files/rob_markov_perf.rst
+++ b/rst_files/rob_markov_perf.rst
@@ -487,10 +487,11 @@ The MPE with robustness function is ``nnash_robust``
 
 The function's code is as follows
 
-.. code:: python3
+.. code:: ipython
 
     from scipy.linalg import solve
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     def nnash_robust(A, C, B1, B2, R1, R2, Q1, Q2, S1, S2, W1, W2, M1, M2,
                      θ1, θ2, beta=1.0, tol=1e-8, max_iter=1000):

--- a/rst_files/samuelson.rst
+++ b/rst_files/samuelson.rst
@@ -350,11 +350,12 @@ Implementation
 
 We'll start by drawing an informative graph from page 189 of :cite:`Sargent1987`
 
-.. code-block:: python3
+.. code-block:: ipython
     :class: collapse
 
     import numpy as np
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     def param_plot():
 

--- a/rst_files/schelling.rst
+++ b/rst_files/schelling.rst
@@ -184,11 +184,12 @@ Here's one solution that does the job we want. If you feel like a
 further exercise you can probably speed up some of the computations and
 then increase the number of agents.
 
-.. code-block:: python3
+.. code-block:: ipython
 
     from random import uniform, seed
     from math import sqrt
     import matplotlib.pyplot as plt
+    %matplotlib inline
     
     seed(10)  # for reproducible random numbers
     

--- a/rst_files/scipy.rst
+++ b/rst_files/scipy.rst
@@ -120,10 +120,11 @@ For this we can use ``scipy.stats``, which provides all of this functionality as
 
 Here's an example of usage
 
-.. code-block:: python3
+.. code-block:: ipython
 
     from scipy.stats import beta
-    import matplotlib.pyplot as plt 
+    import matplotlib.pyplot as plt
+    %matplotlib inline
 
     q = beta(5, 5)      # Beta(a, b), with a = b = 5
     obs = q.rvs(2000)   # 2000 observations

--- a/rst_files/stationary_densities.rst
+++ b/rst_files/stationary_densities.rst
@@ -489,10 +489,11 @@ The following code is example of usage for the stochastic growth model :ref:`des
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     import matplotlib.pyplot as plt
+    %matplotlib inline
     from scipy.stats import lognorm, beta
     from quantecon import LAE
 

--- a/rst_files/uncertainty_traps.rst
+++ b/rst_files/uncertainty_traps.rst
@@ -344,9 +344,10 @@ Modulo randomness, replicate the simulation figures shown above
 Solutions
 =========
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import matplotlib.pyplot as plt
+    %matplotlib inline
     import numpy as np
     import itertools
 

--- a/rst_files/wald_friedman.rst
+++ b/rst_files/wald_friedman.rst
@@ -173,10 +173,11 @@ The bottom panel presents mixtures of these distributions, with various mixing p
 
 
 
-.. code-block:: python3
+.. code-block:: ipython
 
   import numpy as np
   import matplotlib.pyplot as plt
+  %matplotlib inline
   import scipy.stats as st
 
 

--- a/rst_files/writing_good_code.rst
+++ b/rst_files/writing_good_code.rst
@@ -65,10 +65,11 @@ The plots will be grouped into three subfigures
 
 In each subfigure, two parameters are held fixed while another varies
 
-.. code-block:: python3
+.. code-block:: ipython
 
     import numpy as np
     import matplotlib.pyplot as plt
+    %matplotlib inline
 
     # Allocate memory for time series
     k = np.empty(50)


### PR DESCRIPTION
include matplotlib inline to ensure inline graphics for download notebooks and remove from pre-parser in quantecon.build.lectures