### PR TITLE
FIX: Update displaymath for use with sphinxcontrib-jupyter:change_displaymath (A to C)

### DIFF
--- a/rst_files/additive_functionals.rst
+++ b/rst_files/additive_functionals.rst
@@ -185,9 +185,9 @@ In doing so we'll assume that :math:`z_{t+1}` is scalar and that :math:`\tilde x
 .. math::
     :label: ftaf
 
-    \tilde x_{t+1} = \phi_1 \tilde x_{t} + \phi_2 \tilde x_{t-1} 
-    + \phi_3 \tilde x_{t-2}
-    + \phi_4 \tilde x_{t-3} + \sigma z_{t+1} 
+    \tilde x_{t+1} = \phi_1 \tilde x_{t} + \phi_2 \tilde x_{t-1} +
+    \phi_3 \tilde x_{t-2} +
+    \phi_4 \tilde x_{t-3} + \sigma z_{t+1} 
 
 
 Let the increment in :math:`\{y_t\}` obey

--- a/rst_files/amss.rst
+++ b/rst_files/amss.rst
@@ -122,8 +122,8 @@ The government’s budget constraint in period :math:`t` at history :math:`s^t` 
 
     \begin{aligned}
     b_t(s^{t-1}) 
-        & =    \tau^n_t(s^t) n_t(s^t) - g_t(s_t) - T_t(s^t)
-                       + {b_{t+1}(s^t) \over R_t(s^t )} 
+        & =    \tau^n_t(s^t) n_t(s^t) - g_t(s_t) - T_t(s^t) +
+                       {b_{t+1}(s^t) \over R_t(s^t )} 
         \\
         & \equiv z(s^t) + {b_{t+1}(s^t) \over R_t(s^t )},
     \end{aligned}
@@ -326,8 +326,8 @@ Then a Lagrangian for the Ramsey problem can  be represented as
        &= \EE_{0} \sum_{t=0}^\infty \beta^t
                              \biggl\{ u\left(c_t(s^t), 1-c_t(s^t)-g_t(s_t)\right)   
             \\
-       &  \qquad + \Psi_t(s^t)\, u_c(s^{t}) \,z(s^{t})
-                       - \gamma_t(s^t)\, u_c(s^{t}) \, b_t(s^{t-1})  \biggr\}
+       &  \qquad + \Psi_t(s^t)\, u_c(s^{t}) \,z(s^{t}) -
+                       \gamma_t(s^t)\, u_c(s^{t}) \, b_t(s^{t-1})  \biggr\}
     \end{aligned}
 
 
@@ -354,8 +354,8 @@ to :math:`c_t(s^t)` can be expressed as
 
     \begin{aligned}
       u_c(s^t)-u_{\ell}(s^t) &+ \Psi_t(s^t)\left\{ \left[
-        u_{cc}(s^t) - u_{c\ell}(s^{t})\right]z(s^{t}) 
-        + u_{c}(s^{t})\,z_c(s^{t}) \right\}  
+        u_{cc}(s^t) - u_{c\ell}(s^{t})\right]z(s^{t}) +
+        u_{c}(s^{t})\,z_c(s^{t}) \right\}  
         \\
         & \hspace{35mm} - \gamma_t(s^t)\left[
         u_{cc}(s^{t}) - u_{c\ell}(s^{t})\right]b_t(s^{t-1}) =0 
@@ -496,8 +496,8 @@ Write equation :eq:`eqn:AMSSapp2` as
 .. math::
     :label: eqn:AMSSapp2b
 
-    b_t(s^{t-1})  = c_t(s^t) -  { \frac{u_{l,t}(s^t)}{u_{c,t}(s^t)}} n_t(s^t) 
-    + {\frac{\beta (\EE_t u_{c,t+1}) b_{t+1}(s^t)}{u_{c,t}}}
+    b_t(s^{t-1})  = c_t(s^t) -  { \frac{u_{l,t}(s^t)}{u_{c,t}(s^t)}} n_t(s^t) +
+    {\frac{\beta (\EE_t u_{c,t+1}) b_{t+1}(s^t)}{u_{c,t}}}
 
 
 The right side of equation :eq:`eqn:AMSSapp2b` expresses the time :math:`t` value of government debt
@@ -533,8 +533,8 @@ satisfies the Bellman equation
 .. math::
     :label: eqn:AMSSapp5
 
-    V(x_-,s_-) = \max_{\{n(s), x(s)\}} \sum_s \Pi(s|s_-) \left[ u(n(s) 
-    - g(s), 1-n(s)) + \beta V(x(s),s) \right]
+    V(x_-,s_-) = \max_{\{n(s), x(s)\}} \sum_s \Pi(s|s_-) \left[ u(n(s) -
+    g(s), 1-n(s)) + \beta V(x(s),s) \right]
 
 
 subject to the following collection of implementability constraints, one

--- a/rst_files/amss2.rst
+++ b/rst_files/amss2.rst
@@ -152,11 +152,11 @@ For :math:`t \geq 1`, these take the form
     :label: TS_barg10a
 
     \begin{aligned}
-      (1+\Phi) &u_c(c,1-c-g) + \Phi \bigl[c u_{cc}(c,1-c-g)
-        -  (c+g) u_{\ell c}(c,1-c-g) \bigr]
+      (1+\Phi) &u_c(c,1-c-g) + \Phi \bigl[c u_{cc}(c,1-c-g) -
+        (c+g) u_{\ell c}(c,1-c-g) \bigr]
         \\
-        &= (1+\Phi) u_{\ell}(c,1-c-g) + \Phi \bigl[c u_{c\ell}(c,1-c-g)
-        -  (c+g) u_{\ell \ell}(c,1-c-g)  \bigr]
+        &= (1+\Phi) u_{\ell}(c,1-c-g) + \Phi \bigl[c u_{c\ell}(c,1-c-g) -
+        (c+g) u_{\ell \ell}(c,1-c-g)  \bigr]
     \end{aligned}
 
 There is one such equation for each value of the Markov state :math:`s_t`
@@ -167,11 +167,11 @@ In addition, given an initial Markov state, the time :math:`t=0` quantities :mat
     :label: TS_barg11b
 
     \begin{aligned}
-          (1+\Phi) &u_c(c,1-c-g) + \Phi \bigl[c u_{cc}(c,1-c-g)
-            -  (c+g) u_{\ell c}(c,1-c-g) \bigr]
+          (1+\Phi) &u_c(c,1-c-g) + \Phi \bigl[c u_{cc}(c,1-c-g) -
+            (c+g) u_{\ell c}(c,1-c-g) \bigr]
             \\
-            &= (1+\Phi) u_{\ell}(c,1-c-g) + \Phi \bigl[c u_{c\ell}(c,1-c-g)
-            -  (c+g) u_{\ell \ell}(c,1-c-g)  \bigr] + \Phi (u_{cc} - u_{c,\ell}) b_0
+            &= (1+\Phi) u_{\ell}(c,1-c-g) + \Phi \bigl[c u_{c\ell}(c,1-c-g) -
+            (c+g) u_{\ell \ell}(c,1-c-g)  \bigr] + \Phi (u_{cc} - u_{c,\ell}) b_0
     \end{aligned}
 
 In addition, the time :math:`t=0` budget constraint is satisfied at :math:`c_0` and initial government debt

--- a/rst_files/arma.rst
+++ b/rst_files/arma.rst
@@ -287,8 +287,8 @@ average process*, or ARMA(:math:`p,q`), if it can be written as
 .. math::
     :label: arma
 
-    X_t = \phi_1 X_{t-1} + \cdots + \phi_p X_{t-p}
-        + \epsilon_t + \theta_1 \epsilon_{t-1} + \cdots + \theta_q \epsilon_{t-q}
+    X_t = \phi_1 X_{t-1} + \cdots + \phi_p X_{t-p} +
+        \epsilon_t + \theta_1 \epsilon_{t-1} + \cdots + \theta_q \epsilon_{t-q}
 
 
 where :math:`\{ \epsilon_t \}` is white noise

--- a/rst_files/calvo.rst
+++ b/rst_files/calvo.rst
@@ -211,7 +211,7 @@ is:
 .. math::
     :label: eq_old6
 
-    - s(\theta_t, \mu_t) \equiv - r(x_t,\mu_t) = \begin{bmatrix} 1 \\ \theta_t \end{bmatrix}' \begin{bmatrix} a_0 & -\frac{a_1 \alpha}{2} \\ -\frac{a_1 \alpha}{2} & -\frac{a_2 \alpha^2}{2} \end{bmatrix} \begin{bmatrix} 1 \\ \theta_t \end{bmatrix} - \frac{c}{2} \mu_t^2 =  - x_t'Rx_t - Q \mu_t^2
+    -s(\theta_t, \mu_t) \equiv - r(x_t,\mu_t) = \begin{bmatrix} 1 \\ \theta_t \end{bmatrix}' \begin{bmatrix} a_0 & -\frac{a_1 \alpha}{2} \\ -\frac{a_1 \alpha}{2} & -\frac{a_2 \alpha^2}{2} \end{bmatrix} \begin{bmatrix} 1 \\ \theta_t \end{bmatrix} - \frac{c}{2} \mu_t^2 =  - x_t'Rx_t - Q \mu_t^2
 
 Household welfare is summarized by:
 

--- a/rst_files/chang_credible.rst
+++ b/rst_files/chang_credible.rst
@@ -198,12 +198,12 @@ time :math:`t` component
 The government faces a sequence of budget constraints with time
 :math:`t` component
 
-.. math:: - x_t = q_t (M_t - M_{t-1})
+.. math:: -x_t = q_t (M_t - M_{t-1})
 
 which, by using the definitions of :math:`m_t` and :math:`h_t`, can also
 be expressed as
 
-.. math:: - x_t = m_t (1-h_t)
+.. math:: -x_t = m_t (1-h_t)
    :label: eqn_chang2a
 
 The  restrictions :math:`m_t \in [0, \bar m]` and :math:`h_t \in \Pi` evidently 
@@ -365,7 +365,8 @@ Chang works with
 * A recursive representation of a credible government policy is a pair of 
   initial conditions :math:`(w_0, \theta_0)` and a five-tuple of functions
 
- .. math::
+  .. math::
+
     h(w_t, \theta_t), m(h_t, w_t, \theta_t), x(h_t, w_t, \theta_t), \chi(h_t, w_t, \theta_t),\Psi(h_t, w_t, \theta_t)
 
   mapping :math:`w_t,\theta_t` and in some cases :math:`h_t` into 

--- a/rst_files/chang_ramsey.rst
+++ b/rst_files/chang_ramsey.rst
@@ -191,12 +191,12 @@ time :math:`t` component
 The government faces a sequence of budget constraints with time
 :math:`t` component
 
-.. math:: - x_t = q_t (M_t - M_{t-1})
+.. math:: -x_t = q_t (M_t - M_{t-1})
 
 which by using the definitions of :math:`m_t` and :math:`h_t` can also
 be expressed as
 
-.. math:: - x_t = m_t (1-h_t)
+.. math:: -x_t = m_t (1-h_t)
    :label: eqn_chang_ramsey2a
 
 The  restrictions :math:`m_t \in [0, \bar m]` and :math:`h_t \in \Pi` evidently
@@ -375,10 +375,12 @@ Chang constructs the following objects
      .. math::
         :label: Chang500
         
-        \begin{split} h_t & = h(\theta_t) \\
-                m_t & = m(\theta_t) \\
-                x_t & = x(\theta_t) \\
-                \theta_{t+1} & = \Psi(\theta_t) \end{split}
+        \begin{split} 
+        h_t & = h(\theta_t) \\
+        m_t & = m(\theta_t) \\
+        x_t & = x(\theta_t) \\
+        \theta_{t+1} & = \Psi(\theta_t) 
+        \end{split}
 
      starting from :math:`\theta_0`
 

--- a/rst_files/classical_filtering.rst
+++ b/rst_files/classical_filtering.rst
@@ -403,8 +403,7 @@ Thus, we have
     \left[
         \sum^\infty_{j=0} \delta^j X_{t+j}\vert X_t,\, x_{t-1},
         \ldots
-    \right]
-    =
+    \right] =
     \left[
         {1-\delta c (\delta) L^{-1} c(L)^{-1} \over 1 - \delta L^{-1}}
     \right]


### PR DESCRIPTION
This PR adjust broken math for compatibility with sphinxcontrib-jupyter:change_displaymath

- [x] adjustments for lectures a - c*.rst to fix math sensitivities from nbconvert and displaymath

See https://github.com/QuantEcon/sphinxcontrib-jupyter/pull/154
