### PR TITLE
FIX: remove python from frontpage

### DIFF
--- a/rst_files/index.rst
+++ b/rst_files/index.rst
@@ -19,8 +19,8 @@
 
 .. only:: html
 
-    Table of Contents (Python)
-    *************************************************************
+    Table of Contents
+    *****************
 
 .. raw:: html
 


### PR DESCRIPTION
`python` is now contained in the headers so no longer needed