### PR TITLE
Add make setup, requirements.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ help:
 
 .PHONY: help Makefile
 
+# Install requiremenets for building lectures.
+setup:
+	pip install -r requirements.txt
+
 local:
 	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_images_urlpath=0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+sphinxcontrib-bibtex
+quantecon


### PR DESCRIPTION
- Added an additional Make command `make setup` which reads and installs dependencies listed in `requirements.txt`
- Added requirements.txt file with `sphinxcontrib-bibtex` and `quantecon` dependencies