### PR TITLE
Hide Badges & How to for notebook, show QE logo

### DIFF
--- a/rst_files/_static/includes/lecture_howto_py.raw
+++ b/rst_files/_static/includes/lecture_howto_py.raw
@@ -1,6 +1,12 @@
 .. raw:: html
 
-		<ul class="badges">
+		<div id="qe-notebook-header" style="text-align:right;">
+			<a href="https://quantecon.org/" title="quantecon.org">
+				<img style="width:250px;display:inline;" src="https://assets.quantecon.org/img/qe-menubar-logo.svg" alt="QuantEcon">
+			</a>
+		</div>
+
+		<ul class="badges" style="display:none;">
 			<li><a href="#"><img src="/_static/img/jupyter-notebook-download-blue.svg" id="notebook_download_badge"></a></li>
 			<li><a href="#"><img src="/_static/img/pdf-download-blue.svg" id="pdf_download_badge"></a></li>
 			<li><a href="/status.html"><img src="https://img.shields.io/badge/Execution%20test-not%20available-lightgrey.svg" id="executability_status_badge"></a></li>
@@ -15,7 +21,7 @@
 		document.getElementById('pdf_download_badge').parentElement.setAttribute('href', pdfDownloadLink);
 		</script>
 
-		<div class="how-to">
+		<div class="how-to" style="display:none;">
 			<a href="#" class="toggle"><span class="icon icon-angle-double-down"></span>How to read this lecture...</a>
 			<div class="how-to-content">
 				<p>Code should execute sequentially if run in a Jupyter notebook</p>


### PR DESCRIPTION
- Adding a right aligned QE logo to notebook header
- Added inline styles to hide the "Badges" and "How to read" for notebooks (CSS added to make visible on HTML site)

![image](https://user-images.githubusercontent.com/5886045/53218038-a9a6c880-36ae-11e9-902e-c39b233c5cec.png)
