### PR TITLE
Makefile additions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,11 @@ notebooks:
 	make jupyter
 
 preview:
-	cd _build/jupyter/ && jupyter notebook $(basename $(LECTURE))'.ipynb'
+ifdef LECTURE
+	cd _build/jupyter/ && jupyter notebook $(basename $(LECTURE)).ipynb
+else
+	cd _build/jupyter/ && jupyter notebook
+endif
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,14 @@ notebooks:
 	make jupyter
 
 preview:
-ifdef LECTURE
-	cd _build/jupyter/ && jupyter notebook $(basename $(LECTURE)).ipynb
+ifdef lecture
+	cd _build/jupyter/ && jupyter notebook $(basename $(lecture)).ipynb
 else
 	cd _build/jupyter/ && jupyter notebook
 endif
+
+view:
+	make preview
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,11 @@ setup:
 local:
 	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -D jupyter_images_urlpath=0
 
+notebooks:
+	make jupyter
+
 preview:
-	cd _build/jupyter/ && jupyter notebook
+	cd _build/jupyter/ && jupyter notebook $(basename $(LECTURE))'.ipynb'
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
- Added new command `make notebooks` same function as `make jupyter` (semantics)
- Added option to preview lecture directly `make preview LECTURE=amss`
- Added catch for above addition accepting input `LECTURE=amss.rst` `LECTURE=amss.ipynb` `LECTURE=amss`
- Default `make preview` launches notebooks directory
- Added `make view` to Makefile, mimics `make preview`