### PR TITLE
Replace deprecated normed kwarg with density in hist()

### DIFF
--- a/source/_static/code/linear_models/paths_and_hist.py
+++ b/source/_static/code/linear_models/paths_and_hist.py
@@ -43,6 +43,6 @@ for i in range(20):
 
 y = y.flatten()
 axes[1].set_ylim(ymin, ymax)
-axes[1].hist(sample, bins=16, normed=True, orientation='horizontal', alpha=0.5)
+axes[1].hist(sample, bins=16, density=True, orientation='horizontal', alpha=0.5)
 
 plt.show()

--- a/source/_static/code/linear_models/tsh_hg.py
+++ b/source/_static/code/linear_models/tsh_hg.py
@@ -28,7 +28,7 @@ mu_x, mu_y, Sigma_x, Sigma_y = ar.stationary_distributions()
 f_y = norm(loc=float(mu_y), scale=float(np.sqrt(Sigma_y)))
 
 y = y.flatten()
-ax.hist(y, bins=50, normed=True, alpha=0.4)
+ax.hist(y, bins=50, density=True, alpha=0.4)
 
 ygrid = np.linspace(ymin, ymax, 150)
 ax.plot(ygrid, f_y.pdf(ygrid), 'k-', lw=2, alpha=0.8, label='true density')

--- a/source/rst/multiplicative_functionals.rst
+++ b/source/rst/multiplicative_functionals.rst
@@ -370,8 +370,8 @@ Let's see a histogram of the log-likelihoods under the true and the alternative 
 
     fig, ax = plt.subplots(figsize=(8, 6))
     
-    plt.hist(LLT, bins=50, alpha=0.5, label='True', normed=True)
-    plt.hist(LLT2, bins=50, alpha=0.5, label='Alternative', normed=True)
+    plt.hist(LLT, bins=50, alpha=0.5, label='True', density=True)
+    plt.hist(LLT2, bins=50, alpha=0.5, label='Alternative', density=True)
     plt.vlines(np.mean(LLT), 0, 10, color='k', linestyle="--", linewidth= 4)
     plt.vlines(np.mean(LLT2), 0, 10, color='k', linestyle="--", linewidth= 4)
     plt.legend()

--- a/source/rst/scipy.rst
+++ b/source/rst/scipy.rst
@@ -131,7 +131,7 @@ Here's an example of usage
     grid = np.linspace(0.01, 0.99, 100)
 
     fig, ax = plt.subplots(figsize=(10, 6))
-    ax.hist(obs, bins=40, normed=True)
+    ax.hist(obs, bins=40, density=True)
     ax.plot(grid, q.pdf(grid), 'k-', linewidth=2)
     plt.show()
 
@@ -181,7 +181,7 @@ For example, the previous code can be replaced by
     grid = np.linspace(0.01, 0.99, 100)
 
     fig, ax = plt.subplots()
-    ax.hist(obs, bins=40, normed=True)
+    ax.hist(obs, bins=40, density=True)
     ax.plot(grid, beta.pdf(grid, 5, 5), 'k-', linewidth=2)
     plt.show()
 


### PR DESCRIPTION
This replaces all uses of the `normed` kwarg of the matplotlib `hist` function with its replacement, `density`.

Search results for `normed`: https://github.com/QuantEcon/lecture-source-py/search?q=normed&unscoped_q=normed

Documentation showing `normed` is deprecated (it currently throws a warning): https://matplotlib.org/api/_as_gen/matplotlib.pyplot.hist.html