### PR TITLE
Add return statements to bisect function

### DIFF
--- a/source/rst/scipy.rst
+++ b/source/rst/scipy.rst
@@ -518,9 +518,9 @@ Here's a reasonable solution:
             middle = 0.5 * (upper + lower)
             print(f'Current mid point = {middle}')
             if f(middle) > 0:   # Implies root is between lower and middle
-                bisect(f, lower, middle)
+                return bisect(f, lower, middle)
             else:               # Implies root is between middle and upper
-                bisect(f, middle, upper)
+                return bisect(f, middle, upper)
 
 
 We can test it as follows


### PR DESCRIPTION
This ensures the bisect function returns the result. Currently it only prints the midpoints.

See https://discourse.quantecon.org/t/scipy-lecture-question-1-recursive-function/528/2