### PR TITLE
Fix Typo in Dynamic Stackelberg Code

### DIFF
--- a/source/rst/dyn_stack.rst
+++ b/source/rst/dyn_stack.rst
@@ -1210,7 +1210,7 @@ Hint: remember the components of :math:`X_t`
         dist_vec2 = (F_iter - (β * la.inv(Q + β * B_tilde.T @ P_iter @ B_tilde) 
                      @ B_tilde.T @ P_iter @ A_tilde))
                      
-        if np.max(np.abs(dist_vec)) < 1e-8:
+        if np.max(np.abs(dist_vec2)) < 1e-8:
             F_iter
         else: 
             print("The policy didn't converge: try increasing the number of outer loop iterations")


### PR DESCRIPTION
In the process of applying Tom's rewrite to the Julia lectures, I found what I think is a typo in the lecture. 

As written, we're checking the `dist_vec` vector twice, and `dist_vec2` zero times. 