### PR TITLE
add (parallel=parallel_flag)

### DIFF
--- a/source/rst/odu.rst
+++ b/source/rst/odu.rst
@@ -625,7 +625,7 @@ operator ``Q``
 
             return π_new
 
-        @njit
+        @njit(parallel=parallel_flag)
         def Q(ω):
             """
 


### PR DESCRIPTION
Enable controlling the parallel option in `@njit` for the function `Q`.
Similar to #303 3.