### PR TITLE
class: hide-output is added in stationary_densities.rst

### DIFF
--- a/source/rst/stationary_densities.rst
+++ b/source/rst/stationary_densities.rst
@@ -16,6 +16,7 @@
 In addition to what's in Anaconda, this lecture will need the following libraries
 
 .. code-block:: ipython
+  :class: hide-output
 
   !pip install quantecon
 


### PR DESCRIPTION
@jstac Seems like this was the only lecture which did not have the class: hide-output