### PR TITLE
FIX: Adding back missing github icon

### DIFF
--- a/theme/templates/lectures-nbconvert.tpl
+++ b/theme/templates/lectures-nbconvert.tpl
@@ -154,12 +154,13 @@
 {% if nb_lang == 'py' and not indexPage %}
 
 						<ul class="badges">
-							<li><a href="https://colab.research.google.com/github/QuantEcon/lecture-py-notebooks/blob/master/{{nb_filename_with_path}}.ipynb"><img src="/_static/img/jupyter-notebook-run-006400.svg" id="notebook_run_badge"></a></li>
+							<li><a target="_blank" href="https://colab.research.google.com/github/QuantEcon/lecture-py-notebooks/blob/master/{{nb_filename_with_path}}.ipynb"><img src="/_static/img/jupyter-notebook-run-006400.svg" id="notebook_run_badge"></a></li>
 							{% if download_nb == True %}
 								<li><a href="/{{nb_lang}}/_downloads/ipynb/{{nb_filename_with_path}}.ipynb"><img src="/_static/img/jupyter-notebook-download-blue.svg" id="notebook_download_badge"></a></li>
 								<li><a href="/_downloads/pdf/py/{{nb_filename_with_path}}.pdf"><img src="/_static/img/pdf-download-blue.svg" id="pdf_download_badge"></a></li>
 							{% endif %}
 							<li><a href="/{{nb_lang}}/status.html"><img src="https://img.shields.io/badge/Execution%20test-not%20available-lightgrey.svg" id="executability_status_badge"></a></li>
+							<li class="ml-a"><a target="_blank" href="https://github.com/QuantEcon/lecture-source-py/blob/master/source/rst/{{nb_filename}}.rst"><img src="/_static/img/github-icon.svg"></a></li>
 						</ul>
 
 						<div class="how-to">


### PR DESCRIPTION
Github icon linking the Github page of each notebook went missing in the template files. This PR fixes that.