### PR TITLE
FIX: update lang_synonym to include ipython3

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -418,7 +418,7 @@ jupyter_download_nb = False
 jupyter_images_urlpath = None
 
 #Allow ipython as a language synonym for blocks to be ipython highlighted
-jupyter_lang_synonyms = ["ipython"]
+jupyter_lang_synonyms = ["ipython", "ipython3"]
 
 #Execute skip-test code blocks for rendering of website (this will need to be ignored in coverage testing)
 jupyter_ignore_skip_test = True


### PR DESCRIPTION
This PR adds support for `ipython3` blocks to be included as executable cells.

- [x] fixes `dyn_stack` issue with imports (on latest coverage)