### PR TITLE
FIX: remove unnecessary _static path in jupyter_static_path

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -379,7 +379,7 @@ jupyter_conversion_mode = "all"
 jupyter_write_metadata = False
 
 # Location for _static folder
-jupyter_static_file_path = ["source/_static", "_static"]
+jupyter_static_file_path = ["source/_static"]
 
 # Configure Jupyter Kernels
 jupyter_kernels = {


### PR DESCRIPTION
This PR removes an unecesary `_static` path. 

- [ ] requires `sphinxcontrib-jupyter=0.4.4` which has a release target of 30th August 2019