### PR TITLE
FIX: fix error in python-essentials lecture

### DIFF
--- a/source/rst/python_essentials.rst
+++ b/source/rst/python_essentials.rst
@@ -1050,12 +1050,12 @@ Here's one solution:
 .. code-block:: python3
 
     def f(string):
-    count = 0
-    for letter in string:
-        if letter == letter.upper() and letter.isalpha():
-            count += 1
-    return count
-    f('The Rain in Spain')
+        count = 0
+        for letter in string:
+            if letter == letter.upper() and letter.isalpha():
+                count += 1
+        return count
+        f('The Rain in Spain')
 
 
 An alternative, more pythonic solution, would be:


### PR DESCRIPTION
This PR fixes some whitespace that must have been removed from `python essentials` `exercise 3`