### PR TITLE
PDF: Enable unicode in verbatim blocks

### DIFF
--- a/theme/templates/latex.tpl
+++ b/theme/templates/latex.tpl
@@ -91,6 +91,9 @@
 
 \DeclareTextFontCommand{\texttt}{\ttfamily}
 
+% Enable Unicode characters in `Out` code-blocks within verbatim
+\usepackage{pmboxdraw}
+
 % renew commands %
 % Set max figure width to be 80% of text width, for now hardcoded.
 \renewcommand{\includegraphics}[1]{\begin{center}\Oldincludegraphics[width=.8\maxwidth]{#1}\end{center}}


### PR DESCRIPTION
This PR enables support for unicode in verbatim environements such as in `about_py`

![image](https://user-images.githubusercontent.com/8263752/66620698-2d58f980-ec2d-11e9-9b4e-29466ed6a540.png)
