### PR TITLE
Revert math size change

### DIFF
--- a/theme/static/css/python.css
+++ b/theme/static/css/python.css
@@ -644,6 +644,7 @@ a .math {color: #0072bc;}
 span.math {font-size:0.92rem;}
 .MathJax {color:#333;margin: 2em 0;}
 a .MathJax {color: #0072bc;}
+span.MathJax {font-size:0.92rem;}
 
 
 /* Device media styles */


### PR DESCRIPTION
Prematurely merged this branch into master. Reverting the change to MathJax rendering size.
Need to review further.