### PR TITLE
Correct SymPyDeprecationWarning

### DIFF
--- a/source/rst/complex_and_trig.rst
+++ b/source/rst/complex_and_trig.rst
@@ -299,7 +299,7 @@ condition:
 
     # Solve for ω
     ## Note: we choose the solution near 0
-    eq1 = Eq(x1/x0 - r * cos(ω+θ) / cos(ω))
+    eq1 = Eq(x1/x0 - r * cos(ω+θ) / cos(ω), 0)
     ω = nsolve(eq1, ω, 0)
     ω = np.float(ω)
     print(f'ω = {ω:1.3f}')


### PR DESCRIPTION
```
/srv/conda/envs/notebook/lib/python3.7/site-packages/sympy/core/relational.py:470: SymPyDeprecationWarning: 

Eq(expr) with rhs default to 0 has been deprecated since SymPy 1.5.
Use Eq(expr, 0) instead. See
https://github.com/sympy/sympy/issues/16587 for more info.

  deprecated_since_version="1.5"
```
https://github.com/QuantEcon/quantecon-notebooks-python/pull/6