### PR TITLE
finite_markov_rephrasing

### DIFF
--- a/source/rst/finite_markov.rst
+++ b/source/rst/finite_markov.rst
@@ -954,7 +954,7 @@ Here
 
 * The black dot is :math:`\psi^*`.
 
-The code for the figure can be found `here <https://github.com/QuantEcon/QuantEcon.lectures.code/blob/master/finite_markov/mc_convergence_plot.py>`__ --- you might like to try experimenting with different initial conditions.
+You might like to try experimenting with different initial conditions.
 
 
 


### PR DESCRIPTION
Hi @jstac , removing redundant link and rephrasing in the [finite markov lecture](https://python.quantecon.org/finite_markov.html#Convergence-to-Stationarity). As we discussed in the closed [PR](https://github.com/QuantEcon/lecture-source-py/pull/906). 