### PR TITLE
additive_functions_add_ref_and_boxes

### DIFF
--- a/source/rst/additive_functionals.rst
+++ b/source/rst/additive_functionals.rst
@@ -961,7 +961,7 @@ and
     \tilde e(x) = \exp[g(x)] = \exp \bigl[ D' (I - A)^{-1} x \bigr]
 
 
-An instance of class `AMF_LSS_VAR <https://github.com/QuantEcon/QuantEcon.lectures.code/blob/master/additive_functionals/amflss.py>`__ includes this associated multiplicative functional as an attribute.
+An instance of class ``AMF_LSS_VAR`` (:ref:`above <amf_lss>`)  includes this associated multiplicative functional as an attribute.
 
 Let's plot this multiplicative functional for our example.
 
@@ -1182,9 +1182,9 @@ We'll do this by formulating the additive functional as a linear state space mod
             return llh[-1]
 
 
-The heavy lifting is done inside the `AMF_LSS_VAR` class.
+The heavy lifting is done inside the ``AMF_LSS_VAR`` class.
 
-The following code adds some simple functions that make it straightforward to generate sample paths from an instance of `AMF_LSS_VAR`.
+The following code adds some simple functions that make it straightforward to generate sample paths from an instance of ``AMF_LSS_VAR``.
 
 
 


### PR DESCRIPTION
Hi @jstac , I have removed the external link [here](https://python.quantecon.org/additive_functionals.html#Associated-Multiplicative-Functional) to the old repository and added a reference to the code [block](https://python.quantecon.org/additive_functionals.html#Simulation) in the lecture. As well as adding code boxes where required.