### PR TITLE
finite_markov_ex_edit

### DIFF
--- a/source/rst/finite_markov.rst
+++ b/source/rst/finite_markov.rst
@@ -1279,8 +1279,6 @@ Since :math:`r` is the stationary distribution of :math:`P`, assuming that the u
 Your exercise is to apply this ranking algorithm to the graph pictured above
 and return the list of pages ordered by rank.
 
-The data for this graph is in the ``web_graph_data.txt`` file --- you can also view it `here <https://github.com/QuantEcon/QuantEcon.lectures.code/blob/master/finite_markov/web_graph_data.txt>`__.
-
 There is a total of 14 nodes (i.e., web pages), the first named ``a`` and the last named ``n``.
 
 A typical line from the file has the form
@@ -1290,6 +1288,49 @@ A typical line from the file has the form
     d -> h;
 
 This should be interpreted as meaning that there exists a link from ``d`` to ``h``.
+
+The data for this graph is shown below, and read into a file called ``web_graph_data.txt`` when the cell is executed.
+
+.. code-block:: ipython
+
+    %%file web_graph_data.txt
+    a -> d;
+    a -> f;
+    b -> j;
+    b -> k;
+    b -> m;
+    c -> c;
+    c -> g;
+    c -> j;
+    c -> m;
+    d -> f;
+    d -> h;
+    d -> k;
+    e -> d;
+    e -> h;
+    e -> l;
+    f -> a;
+    f -> b;
+    f -> j;
+    f -> l;
+    g -> b;
+    g -> j;
+    h -> d;
+    h -> g;
+    h -> l;
+    h -> m;
+    i -> g;
+    i -> h;
+    i -> n;
+    j -> e;
+    j -> i;
+    j -> k;
+    k -> n;
+    l -> m;
+    m -> g;
+    n -> c;
+    n -> j;
+    n -> m;
 
 To parse this file and extract the relevant information, you can use `regular expressions <https://docs.python.org/3/library/re.html>`_.
 
@@ -1430,51 +1471,6 @@ As :math:`m` gets large, both series converge to zero.
 
 Exercise 2
 ----------
-
-First, save the data into a file called ``web_graph_data.txt`` by
-executing the next cell
-
-.. code-block:: ipython
-
-    %%file web_graph_data.txt
-    a -> d;
-    a -> f;
-    b -> j;
-    b -> k;
-    b -> m;
-    c -> c;
-    c -> g;
-    c -> j;
-    c -> m;
-    d -> f;
-    d -> h;
-    d -> k;
-    e -> d;
-    e -> h;
-    e -> l;
-    f -> a;
-    f -> b;
-    f -> j;
-    f -> l;
-    g -> b;
-    g -> j;
-    h -> d;
-    h -> g;
-    h -> l;
-    h -> m;
-    i -> g;
-    i -> h;
-    i -> n;
-    j -> e;
-    j -> i;
-    j -> k;
-    k -> n;
-    l -> m;
-    m -> g;
-    n -> c;
-    n -> j;
-    n -> m;
-
 
 .. code-block:: python3
 


### PR DESCRIPTION
Hi @jstac , removed external link in ex2 ([here](https://python.quantecon.org/finite_markov.html#Exercise-2)) to the old repository, and rephrased sentences in ex2, and moved the code block  that generated ``web_graph_data.txt`` out of solutions to ex2 so the user can see that code. 