### PR TITLE
functions_issue

### DIFF
--- a/source/rst/functions.rst
+++ b/source/rst/functions.rst
@@ -463,7 +463,7 @@ Exercise 4
 
         for i in range(10):
             U = uniform()
-            count = count + 1 if U < 0.5 else 0
+            count = count + (1 if U < 0.5 else 0)
             if count == k:
                 payoff = 1
 


### PR DESCRIPTION
Hi @jstac , I found that count in exercise 3 cannot calculate correctly because if U>=0.5, "count" become 0, not "count + 0". It means once U>=0.5, "count" restart to count from 0. So I put bracket in this.
